### PR TITLE
Specify Initial Sequence Number

### DIFF
--- a/packager/app/muxer_flags.cc
+++ b/packager/app/muxer_flags.cc
@@ -53,3 +53,7 @@ DEFINE_int32(transport_stream_timestamp_offset_ms,
              "input. For example, timestamps from ISO-BMFF after adjusted by "
              "EditList could be negative. In transport streams, timestamps are "
              "not allowed to be less than zero.");
+DEFINE_int32(mp4_initial_sequence_number,
+             1,
+             "Sets the initialize sequence number in the mp4 moof->mfhd. "
+             "Otherwise defaults to 1.");

--- a/packager/app/muxer_flags.h
+++ b/packager/app/muxer_flags.h
@@ -20,5 +20,6 @@ DECLARE_bool(generate_sidx_in_media_segments);
 DECLARE_string(temp_dir);
 DECLARE_bool(mp4_include_pssh_in_stream);
 DECLARE_int32(transport_stream_timestamp_offset_ms);
+DECLARE_int32(mp4_initial_sequence_number);
 
 #endif  // APP_MUXER_FLAGS_H_

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -413,6 +413,7 @@ base::Optional<PackagingParams> GetPackagingParams() {
   mp4_params.generate_sidx_in_media_segments =
       FLAGS_generate_sidx_in_media_segments;
   mp4_params.include_pssh_in_stream = FLAGS_mp4_include_pssh_in_stream;
+  mp4_params.initial_sequence_number = FLAGS_mp4_initial_sequence_number;
 
   packaging_params.transport_stream_timestamp_offset_ms =
       FLAGS_transport_stream_timestamp_offset_ms;

--- a/packager/media/formats/mp4/segmenter.cc
+++ b/packager/media/formats/mp4/segmenter.cc
@@ -90,7 +90,7 @@ Status Segmenter::Initialize(
 
   // Use the reference stream's time scale as movie time scale.
   moov_->header.timescale = sidx_->timescale;
-  moof_->header.sequence_number = 1;
+  moof_->header.sequence_number = options_.mp4_params.initial_sequence_number;
 
   // Fill in version information.
   const std::string version = GetPackagerVersion();

--- a/packager/media/public/mp4_output_params.h
+++ b/packager/media/public/mp4_output_params.h
@@ -20,6 +20,7 @@ struct Mp4OutputParams {
   /// Note that it is required by spec if segment_template contains $Times$
   /// specifier.
   bool generate_sidx_in_media_segments = true;
+  int initial_sequence_number = 1;
 };
 
 }  // namespace shaka


### PR DESCRIPTION
With this enhancement, you can now specify the initial sequence number
to be used on the generated segments when calling the packager.
With the old implementation, it was always starting with "1".