### PR TITLE
don't add edit box if video track

### DIFF
--- a/packager/media/formats/mp4/mp4_muxer.cc
+++ b/packager/media/formats/mp4/mp4_muxer.cc
@@ -269,7 +269,8 @@ Status MP4Muxer::DelayInitializeMuxer() {
 
     // Generate EditList if needed. See UpdateEditListOffsetFromSample() for
     // more information.
-    if (edit_list_offset_.value() > 0) {
+    const bool isVideoStream = stream->stream_type() == kStreamVideo;
+    if (edit_list_offset_.value() > 0 && !isVideoStream) {
       EditListEntry entry;
       entry.media_time = edit_list_offset_.value();
       entry.media_rate_integer = 1;


### PR DESCRIPTION
This solves the following error from the DASHconformance tool output by skipping the EditListBox if the track is a video track.

**'CMAF check 'cmf2' violated: Section 7.7.2- For video CMAF tracks, the EditListBox SHALL NOT be present', elst box found for Rep 2.

