### PR TITLE
Adding support for hls EXT_X_PROGRAM_DATE_TIME

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -30,3 +30,4 @@ Richard Eklycke <richard@eklycke.se>
 Sanil Raut <sr1990003@gmail.com>
 Sergio Ammirata <sergio@ammirata.net>
 The Chromium Authors <*@chromium.org>
+cdnnow! <*@cdnnow.pro>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -24,6 +24,7 @@
 
 Alen Vrecko <alen.vrecko@gmail.com>
 Anders Hasselqvist <anders.hasselqvist@gmail.com>
+Artem Bogdanov <ykidia@gmail.com>
 Bei Li <beil@google.com>
 Chun-da Chen <capitalm.c@gmail.com>
 Daniel Cantarín <canta@canta.com.ar>

--- a/docs/source/options/hls_options.rst
+++ b/docs/source/options/hls_options.rst
@@ -76,6 +76,13 @@ HLS options
     The EXT-X-MEDIA-SEQUENCE documentation can be read here:
     https://tools.ietf.org/html/rfc8216#section-4.3.3.2.
 
+
+--hls_ext_x_program_date_time <time_offset_ms>
+
+    Adds an EXT-X-PROGRAM-DATE-TIME tag to every Media Segment, with fixed UTC
+    timezone. Time offset is the difference in milliseconds between packaging time
+    and live event time.
+
 --hls_only=0|1
 
     Optional. Defaults to 0 if not specified. If it is set to 1, indicates the

--- a/packager/app/hls_flags.cc
+++ b/packager/app/hls_flags.cc
@@ -30,3 +30,7 @@ DEFINE_int32(hls_media_sequence_number,
               "EXT-X-MEDIA-SEQUENCE value, which allows continuous media "
               "sequence across packager restarts. See #691 for more "
               "information about the reasoning of this and its use cases.");
+DEFINE_int32(hls_ext_x_program_date_time,
+             INT32_MIN,
+             "Enable generation of EXT-X-PROGRAM-DATE-TIME tag with "
+             "a given time offset in milliseconds");

--- a/packager/app/hls_flags.h
+++ b/packager/app/hls_flags.h
@@ -14,5 +14,6 @@ DECLARE_string(hls_base_url);
 DECLARE_string(hls_key_uri);
 DECLARE_string(hls_playlist_type);
 DECLARE_int32(hls_media_sequence_number);
+DECLARE_int32(hls_ext_x_program_date_time);
 
 #endif  // PACKAGER_APP_HLS_FLAGS_H_

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -490,6 +490,11 @@ base::Optional<PackagingParams> GetPackagingParams() {
   hls_params.default_text_language = FLAGS_default_text_language;
   hls_params.media_sequence_number = FLAGS_hls_media_sequence_number;
 
+  if (FLAGS_hls_ext_x_program_date_time != INT32_MIN) {
+    hls_params.add_ext_x_program_date_time = true;
+    hls_params.packaging_time_offset_ms = FLAGS_hls_ext_x_program_date_time;
+  }
+
   TestParams& test_params = packaging_params.test_params;
   test_params.dump_stream_info = FLAGS_dump_stream_info;
   test_params.inject_fake_clock = FLAGS_use_fake_clock_for_muxer;

--- a/packager/hls/base/mock_media_playlist.h
+++ b/packager/hls/base/mock_media_playlist.h
@@ -24,12 +24,13 @@ class MockMediaPlaylist : public MediaPlaylist {
   ~MockMediaPlaylist() override;
 
   MOCK_METHOD1(SetMediaInfo, bool(const MediaInfo& media_info));
-  MOCK_METHOD5(AddSegment,
+  MOCK_METHOD6(AddSegment,
                void(const std::string& file_name,
                     int64_t start_time,
                     int64_t duration,
                     uint64_t start_byte_offset,
-                    uint64_t size));
+                    uint64_t size,
+                    base::Time reference_time));
   MOCK_METHOD3(AddKeyFrame,
                void(int64_t timestamp,
                     uint64_t start_byte_offset,

--- a/packager/hls/base/simple_hls_notifier.h
+++ b/packager/hls/base/simple_hls_notifier.h
@@ -93,6 +93,9 @@ class SimpleHlsNotifier : public HlsNotifier {
 
   base::Lock lock_;
 
+  // Reference time to allow computation of segments associated wall time
+  base::Time reference_time_ = base::Time();
+
   DISALLOW_COPY_AND_ASSIGN(SimpleHlsNotifier);
 };
 

--- a/packager/hls/base/simple_hls_notifier_unittest.cc
+++ b/packager/hls/base/simple_hls_notifier_unittest.cc
@@ -43,6 +43,7 @@ const char kFairPlayKeyUri[] = "skd://www.license.com/getkey?key_id=testing";
 const char kIdentityKeyUri[] = "https://www.license.com/getkey?key_id=testing";
 const HlsPlaylistType kVodPlaylist = HlsPlaylistType::kVod;
 const HlsPlaylistType kLivePlaylist = HlsPlaylistType::kLive;
+const base::Time kRefTime = base::Time();
 
 class MockMasterPlaylist : public MasterPlaylist {
  public:
@@ -215,7 +216,7 @@ TEST_F(SimpleHlsNotifierTest, NotifyNewSegment) {
   const std::string segment_name = "segmentname";
   EXPECT_CALL(*mock_media_playlist,
               AddSegment(StrEq(kTestPrefix + segment_name), kStartTime,
-                         kDuration, 203, kSize));
+                         kDuration, 203, kSize, kRefTime));
 
   const double kLongestSegmentDuration = 11.3;
   const uint32_t kTargetDuration = 12;  // ceil(kLongestSegmentDuration).
@@ -435,7 +436,7 @@ TEST_P(SimpleHlsNotifierRebaseUrlTest, Test) {
 
   if (!test_data_.expected_segment_url.empty()) {
     EXPECT_CALL(*mock_media_playlist,
-                AddSegment(test_data_.expected_segment_url, _, _, _, _));
+                AddSegment(test_data_.expected_segment_url, _, _, _, _, kRefTime));
   }
   EXPECT_CALL(*factory,
               CreateMock(_, StrEq(test_data_.expected_relative_playlist_path),
@@ -544,7 +545,7 @@ TEST_P(LiveOrEventSimpleHlsNotifierTest, NotifyNewSegment) {
   const std::string segment_name = "segmentname";
   EXPECT_CALL(*mock_media_playlist,
               AddSegment(StrEq(kTestPrefix + segment_name), kStartTime,
-                         kDuration, _, kSize));
+                         kDuration, _, kSize, kRefTime));
 
   const double kLongestSegmentDuration = 11.3;
   const uint32_t kTargetDuration = 12;  // ceil(kLongestSegmentDuration).
@@ -617,7 +618,7 @@ TEST_P(LiveOrEventSimpleHlsNotifierTest, NotifyNewSegmentsWithMultipleStreams) {
   EXPECT_TRUE(notifier.NotifyNewStream(media_info, "playlist2.m3u8", "name",
                                        "groupid", &stream_id2));
 
-  EXPECT_CALL(*mock_media_playlist1, AddSegment(_, _, _, _, _)).Times(1);
+  EXPECT_CALL(*mock_media_playlist1, AddSegment(_, _, _, _, _, kRefTime)).Times(1);
   const double kLongestSegmentDuration = 11.3;
   const uint32_t kTargetDuration = 12;  // ceil(kLongestSegmentDuration).
   EXPECT_CALL(*mock_media_playlist1, GetLongestSegmentDuration())
@@ -648,7 +649,7 @@ TEST_P(LiveOrEventSimpleHlsNotifierTest, NotifyNewSegmentsWithMultipleStreams) {
   EXPECT_TRUE(notifier.NotifyNewSegment(stream_id1, "segment_name", kStartTime,
                                         kDuration, 0, kSize));
 
-  EXPECT_CALL(*mock_media_playlist2, AddSegment(_, _, _, _, _)).Times(1);
+  EXPECT_CALL(*mock_media_playlist2, AddSegment(_, _, _, _, _, kRefTime)).Times(1);
   EXPECT_CALL(*mock_media_playlist2, GetLongestSegmentDuration())
       .WillOnce(Return(kLongestSegmentDuration));
   // Not updating other playlists as target duration does not change.

--- a/packager/hls/public/hls_params.h
+++ b/packager/hls/public/hls_params.h
@@ -62,6 +62,9 @@ struct HlsParams {
   /// Custom EXT-X-MEDIA-SEQUENCE value to allow continuous media playback
   /// across packager restarts. See #691 for details.
   uint32_t media_sequence_number = 0;
+  /// Enable generation of EXT-X-PROGRAM-DATE-TIME tag.
+  bool add_ext_x_program_date_time = false;
+  uint32_t packaging_time_offset_ms = 0;
 };
 
 }  // namespace shaka


### PR DESCRIPTION
Rework from https://github.com/google/shaka-packager/pull/814

Adding support for generation of the EXT_X_PROGRAM_DATE_TIME tag for HLS playlists, with fixed UTC timezone
    
Add a new hls option: --hls_ext_x_program_date_time <time_offset_ms>
    
When turned on this option will insert EXT_X_PROGRAM_DATE_TIME in media playlists. 
Date time is computed from local time adjusted by time_offset_ms.

ex playlist:

stream_0.m3u8
```
#EXTM3U
#EXT-X-VERSION:6
## Generated with https://github.com/google/shaka-packager version 81dc2360c2-release
#EXT-X-TARGETDURATION:8
#EXT-X-PLAYLIST-TYPE:VOD
#EXT-X-MAP:URI="360p.mp4",BYTERANGE="823@0"
#EXT-X-PROGRAM-DATE-TIME:2020-09-12T00:24:42.994Z
#EXTINF:8.000,
#EXT-X-BYTERANGE:531320@915
360p.mp4
#EXTINF:4.000,
#EXT-X-BYTERANGE:226186
360p.mp4
#EXTINF:8.000,
#EXT-X-BYTERANGE:543230
360p.mp4
#EXTINF:4.000,
#EXT-X-BYTERANGE:218737
360p.mp4
#EXTINF:4.040,
#EXT-X-BYTERANGE:207063
360p.mp4
#EXT-X-ENDLIST
```

stream_1.m3u8
```
#EXTM3U
#EXT-X-VERSION:6
## Generated with https://github.com/google/shaka-packager version 81dc2360c2-release
#EXT-X-TARGETDURATION:8
#EXT-X-PLAYLIST-TYPE:VOD
#EXT-X-MAP:URI="1080p.mp4",BYTERANGE="862@0"
#EXT-X-PROGRAM-DATE-TIME:2020-09-12T00:24:42.994Z
#EXTINF:8.000,
#EXT-X-BYTERANGE:2618974@954
1080p.mp4
#EXTINF:4.000,
#EXT-X-BYTERANGE:733878
1080p.mp4
#EXTINF:8.000,
#EXT-X-BYTERANGE:2170779
1080p.mp4
#EXTINF:4.000,
#EXT-X-BYTERANGE:710278
1080p.mp4
#EXTINF:4.040,
#EXT-X-BYTERANGE:514582
1080p.mp4
#EXT-X-ENDLIST
```

