### PR TITLE
fix: misleading log output when HLS target duration updates (fixes #969)

### DIFF
--- a/packager/hls/base/media_playlist.cc
+++ b/packager/hls/base/media_playlist.cc
@@ -513,8 +513,8 @@ void MediaPlaylist::SetTargetDuration(int32_t target_duration) {
   if (target_duration_set_) {
     if (target_duration_ == target_duration)
       return;
-    VLOG(1) << "Updating target duration from " << target_duration << " to "
-            << target_duration_;
+    VLOG(1) << "Updating target duration from " << target_duration_ << " to "
+            << target_duration;
   }
   target_duration_ = target_duration;
   target_duration_set_ = true;


### PR DESCRIPTION
Minor fix. The parameters were swapped.