### PR TITLE
fix: set array_completeness in HEVCDecoderConfigurationRecord correctly

### DIFF
--- a/packager/media/codecs/h265_byte_to_unit_stream_converter.cc
+++ b/packager/media/codecs/h265_byte_to_unit_stream_converter.cc
@@ -75,22 +75,22 @@ bool H265ByteToUnitStreamConverter::GetDecoderConfigurationRecord(
   buffer.AppendInt(static_cast<uint8_t>(3) /* numOfArrays */);
 
   // More parameter set NALUs may follow when strip_parameter_set_nalus is disabled.
-  const uint8_t kArrayCompleteness = strip_parameter_set_nalus() ? 0x80 : 0;
+  const uint8_t array_completeness = strip_parameter_set_nalus() ? 0x80 : 0;
 
   // VPS
-  buffer.AppendInt(static_cast<uint8_t>(kArrayCompleteness | Nalu::H265_VPS));
+  buffer.AppendInt(static_cast<uint8_t>(array_completeness | Nalu::H265_VPS));
   buffer.AppendInt(static_cast<uint16_t>(1) /* numNalus */);
   buffer.AppendInt(static_cast<uint16_t>(last_vps_.size()));
   buffer.AppendVector(last_vps_);
 
   // SPS
-  buffer.AppendInt(static_cast<uint8_t>(kArrayCompleteness | Nalu::H265_SPS));
+  buffer.AppendInt(static_cast<uint8_t>(array_completeness | Nalu::H265_SPS));
   buffer.AppendInt(static_cast<uint16_t>(1) /* numNalus */);
   buffer.AppendInt(static_cast<uint16_t>(last_sps_.size()));
   buffer.AppendVector(last_sps_);
 
   // PPS
-  buffer.AppendInt(static_cast<uint8_t>(kArrayCompleteness | Nalu::H265_PPS));
+  buffer.AppendInt(static_cast<uint8_t>(array_completeness | Nalu::H265_PPS));
   buffer.AppendInt(static_cast<uint16_t>(1) /* numNalus */);
   buffer.AppendInt(static_cast<uint16_t>(last_pps_.size()));
   buffer.AppendVector(last_pps_);

--- a/packager/media/codecs/h265_byte_to_unit_stream_converter.cc
+++ b/packager/media/codecs/h265_byte_to_unit_stream_converter.cc
@@ -74,8 +74,7 @@ bool H265ByteToUnitStreamConverter::GetDecoderConfigurationRecord(
   buffer.AppendInt(static_cast<uint8_t>(kUnitStreamNaluLengthSize - 1));
   buffer.AppendInt(static_cast<uint8_t>(3) /* numOfArrays */);
 
-  // More parameter set NALUs may follow when strip_parameter_set_nalus is
-  // disabled.
+  // More parameter set NALUs may follow when strip_parameter_set_nalus is disabled.
   const uint8_t array_completeness = strip_parameter_set_nalus() ? 0x80 : 0;
 
   // VPS

--- a/packager/media/codecs/h265_byte_to_unit_stream_converter.cc
+++ b/packager/media/codecs/h265_byte_to_unit_stream_converter.cc
@@ -74,7 +74,8 @@ bool H265ByteToUnitStreamConverter::GetDecoderConfigurationRecord(
   buffer.AppendInt(static_cast<uint8_t>(kUnitStreamNaluLengthSize - 1));
   buffer.AppendInt(static_cast<uint8_t>(3) /* numOfArrays */);
 
-  // More parameter set NALUs may follow when strip_parameter_set_nalus is disabled.
+  // More parameter set NALUs may follow when strip_parameter_set_nalus is
+  // disabled.
   const uint8_t array_completeness = strip_parameter_set_nalus() ? 0x80 : 0;
 
   // VPS

--- a/packager/media/codecs/h265_byte_to_unit_stream_converter.cc
+++ b/packager/media/codecs/h265_byte_to_unit_stream_converter.cc
@@ -74,8 +74,10 @@ bool H265ByteToUnitStreamConverter::GetDecoderConfigurationRecord(
   buffer.AppendInt(static_cast<uint8_t>(kUnitStreamNaluLengthSize - 1));
   buffer.AppendInt(static_cast<uint8_t>(3) /* numOfArrays */);
 
+  // More parameter set NALUs may follow when strip_parameter_set_nalus is disabled.
+  const uint8_t kArrayCompleteness = strip_parameter_set_nalus() ? 0x80 : 0;
+
   // VPS
-  const uint8_t kArrayCompleteness = 0x80;
   buffer.AppendInt(static_cast<uint8_t>(kArrayCompleteness | Nalu::H265_VPS));
   buffer.AppendInt(static_cast<uint16_t>(1) /* numNalus */);
   buffer.AppendInt(static_cast<uint16_t>(last_vps_.size()));


### PR DESCRIPTION
ISO/IEC 14496-15 says about the `HEVCDecoderConfigurationRecord`:
> **array_completeness** when equal to 1 indicates that all NAL units of the given type are in the following
array and none are in the stream; when equal to 0 indicates that additional NAL units of the indicated type may be in the stream; the default and permitted values are constrained by the sample entry name;

This PR sets `array_completeness` to 0 if parameter NAL units may appear in the stream when they are not stripped by `--strip_parameter_set_nalus`.

This should increase player-compatibiltity for streams with mid-stream SAR changes.