### PR TITLE
fix: dash_roles add role=description for DVS audio per DASH-IF-IOP-v4.3

### DIFF
--- a/docs/source/options/dash_stream_descriptors.rst
+++ b/docs/source/options/dash_stream_descriptors.rst
@@ -12,5 +12,5 @@ DASH specific stream descriptor fields
 
     Optional semicolon separated list of values for DASH Role element. The
     value should be one of: **caption**, **subtitle**, **main**, **alternate**,
-    **supplementary**, **commentary** and **dub**. See DASH (ISO/IEC 23009-1)
+    **supplementary**, **commentary**, **description** and **dub**. See DASH (ISO/IEC 23009-1)
     specification for details.

--- a/docs/source/options/dash_stream_descriptors.rst
+++ b/docs/source/options/dash_stream_descriptors.rst
@@ -12,5 +12,5 @@ DASH specific stream descriptor fields
 
     Optional semicolon separated list of values for DASH Role element. The
     value should be one of: **caption**, **subtitle**, **main**, **alternate**,
-    **supplementary**, **commentary**, **description** and **dub**. See DASH (ISO/IEC 23009-1)
-    specification for details.
+    **supplementary**, **commentary**, **description** and **dub**. See 
+    DASH (ISO/IEC 23009-1) specification for details.

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -114,8 +114,8 @@ const char kUsage[] =
     "    in the format: scheme_id_uri=value.\n"
     "  - dash_roles (roles): Optional semicolon separated list of values for\n"
     "    DASH Role elements. The value should be one of: caption, subtitle,\n"
-    "    main, alternate, supplementary, commentary, description and dub. See DASH\n"
-    "    (ISO/IEC 23009-1) specification for details.\n";
+    "    main, alternate, supplementary, commentary, description and dub. See\n"
+    "    DASH (ISO/IEC 23009-1) specification for details.\n";
 
 // Labels for parameters in RawKey key info.
 const char kDrmLabelLabel[] = "label";
@@ -565,7 +565,7 @@ int PackagerMain(int argc, char** argv) {
 #if defined(OS_WIN)
 // Windows wmain, which converts wide character arguments to UTF-8.
 int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
-  std::unique_ptr<char* [], std::function<void(char**)>> utf8_argv(
+  std::unique_ptr<char*[], std::function<void(char**)>> utf8_argv(
       new char*[argc], [argc](char** utf8_args) {
         // TODO(tinskip): This leaks, but if this code is enabled, it crashes.
         // Figure out why. I suspect gflags does something funny with the

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -114,7 +114,7 @@ const char kUsage[] =
     "    in the format: scheme_id_uri=value.\n"
     "  - dash_roles (roles): Optional semicolon separated list of values for\n"
     "    DASH Role elements. The value should be one of: caption, subtitle,\n"
-    "    main, alternate, supplementary, commentary and dub. See DASH\n"
+    "    main, alternate, supplementary, commentary, description and dub. See DASH\n"
     "    (ISO/IEC 23009-1) specification for details.\n";
 
 // Labels for parameters in RawKey key info.

--- a/packager/app/test/packager_test.py
+++ b/packager/app/test/packager_test.py
@@ -709,7 +709,7 @@ class PackagerFunctionalTest(PackagerAppTest):
         self._GetStream(
             'audio',
             dash_accessibilities='urn:tva:metadata:cs:AudioPurposeCS:2007=1',
-            dash_roles='alternate'),
+            dash_roles='description'),
         self._GetStream('video'),
     ]
 

--- a/packager/app/test/testdata/audio-video-with-accessibilities-and-roles/output.mpd
+++ b/packager/app/test/testdata/audio-video-with-accessibilities-and-roles/output.mpd
@@ -12,7 +12,7 @@
     </AdaptationSet>
     <AdaptationSet id="1" contentType="audio" subsegmentAlignment="true">
       <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value="1"/>
-      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="alternate"/>
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="description"/>
       <Representation id="1" bandwidth="133334" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <BaseURL>bear-640x360-audio.mp4</BaseURL>

--- a/packager/mpd/base/adaptation_set.cc
+++ b/packager/mpd/base/adaptation_set.cc
@@ -54,6 +54,8 @@ std::string RoleToText(AdaptationSet::Role role) {
       return "commentary";
     case AdaptationSet::kRoleDub:
       return "dub";
+    case AdaptationSet::kRoleDescription:
+      return "description";
     default:
       return "unknown";
   }

--- a/packager/mpd/base/adaptation_set.h
+++ b/packager/mpd/base/adaptation_set.h
@@ -43,7 +43,8 @@ class AdaptationSet {
     kRoleAlternate,
     kRoleSupplementary,
     kRoleCommentary,
-    kRoleDub
+    kRoleDub,
+    kRoleDescription
   };
 
   virtual ~AdaptationSet();

--- a/packager/mpd/base/period.cc
+++ b/packager/mpd/base/period.cc
@@ -57,6 +57,8 @@ AdaptationSet::Role RoleFromString(const std::string& role_str) {
     return AdaptationSet::Role::kRoleCommentary;
   if (role_str == "dub")
     return AdaptationSet::Role::kRoleDub;
+  if (role_str == "description")
+    return AdaptationSet::Role::kRoleDescription;
   return AdaptationSet::Role::kRoleUnknown;
 }
 


### PR DESCRIPTION
Fixes support for description role for audio DVS tracks. 
as per spec: 
![dash-accessibility-roles](https://user-images.githubusercontent.com/3489396/163890008-4ae2e92c-13d0-494d-a577-fe87493adaa4.png)

