### PR TITLE
fix: webvtt single cue do not fail on EOS

### DIFF
--- a/packager/media/formats/webvtt/webvtt_parser.cc
+++ b/packager/media/formats/webvtt/webvtt_parser.cc
@@ -448,7 +448,7 @@ bool WebVttParser::ParseCue(const std::string& id,
   TextFragment body;
   TextFragmentStyle no_styles;
   for (size_t i = 1; i < block_size; i++) {
-    if (i > 1) {
+    if (i > 1 && i != block_size) {
       body.sub_fragments.emplace_back(no_styles, /* newline= */ true);
     }
     body.sub_fragments.emplace_back(no_styles, block[i]);

--- a/packager/media/formats/webvtt/webvtt_parser_unittest.cc
+++ b/packager/media/formats/webvtt/webvtt_parser_unittest.cc
@@ -208,6 +208,36 @@ TEST_F(WebVttParserTest, ParseOneCue) {
   EXPECT_EQ(settings.text_alignment, TextAlignment::kCenter);
 }
 
+TEST_F(WebVttParserTest, ParseOneCueWithoutNewLine) {
+  const uint8_t text[] =
+      "WEBVTT\n"
+      "\n"
+      "00:01:00.000 --> 01:00:00.000\n"
+      "subtitle";
+
+  ASSERT_NO_FATAL_FAILURE(SetUpAndInitialize());
+
+  ASSERT_TRUE(parser_->Parse(text, sizeof(text) - 1));
+  ASSERT_TRUE(parser_->Flush());
+
+  ASSERT_EQ(streams_.size(), 1u);
+  ASSERT_EQ(samples_.size(), 1u);
+  EXPECT_EQ(samples_[0]->id(), kNoId);
+  EXPECT_EQ(samples_[0]->start_time(), 60000u);
+  EXPECT_EQ(samples_[0]->duration(), 3540000u);
+  ExpectPlainCueWithBody(samples_[0]->body(), "subtitle");
+
+  // No settings
+  const auto& settings = samples_[0]->settings();
+  EXPECT_FALSE(settings.line);
+  EXPECT_FALSE(settings.position);
+  EXPECT_FALSE(settings.width);
+  EXPECT_FALSE(settings.height);
+  EXPECT_EQ(settings.region, "");
+  EXPECT_EQ(settings.writing_direction, WritingDirection::kHorizontal);
+  EXPECT_EQ(settings.text_alignment, TextAlignment::kCenter);
+}
+
 TEST_F(WebVttParserTest, ParseOneCueWithStyle) {
   const uint8_t text[] =
       "WEBVTT\n"


### PR DESCRIPTION
Fixes: https://github.com/shaka-project/shaka-packager/issues/1018
While Parsing cue body check for the block size. 
If it's the last block do not error if it doesn't have a newline.