### PR TITLE
test: Cancel workflow when a PR is updated

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,6 +21,13 @@ on:
         description: "The ref to build and test."
         required: False
 
+# If another instance of this workflow is started for the same PR, cancel the
+# old one.  If a PR is updated and a new test run is started, the old test run
+# will be cancelled automatically to conserve resources.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
If another instance of the PR workflow is started for the same PR,
cancel the old one.  If a PR is updated and a new test run is started,
the old test run will be cancelled automatically to conserve
resources.