### PR TITLE
MOX-5194 Add channel count to adaption set key

### DIFF
--- a/packager/mpd/base/mpd_utils.cc
+++ b/packager/mpd/base/mpd_utils.cc
@@ -151,6 +151,8 @@ std::string GetAdaptationSetKey(const MediaInfo& media_info,
     key.append("video:");
   } else if (media_info.has_audio_info()) {
     key.append("audio:");
+	key.append(std::to_string(media_info.audio_info().num_channels()));
+	key.append(":");
   } else if (media_info.has_text_info()) {
     key.append(MediaInfo_TextInfo_TextType_Name(media_info.text_info().type()));
     key.append(":");


### PR DESCRIPTION
- dash adaption set should not switch when we are dealing with different channels
- include channel count into the adaption set key so we will always end up with another adaption set