### PR TITLE
ci: Parallel build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -128,7 +128,7 @@ jobs:
         # Visual Studio on Windows.  Note that the VS generator is what cmake
         # calls a "multi-configuration" generator, and so the desired build
         # type must be specified for Windows.
-        run: cmake --build build/ --config "${{ matrix.build_type }}"
+        run: cmake --build build/ --config "${{ matrix.build_type }}" --parallel
 
       - name: Test
         run: cd build; ctest -C "${{ matrix.build_type }}" -V


### PR DESCRIPTION
Build in parallel with however many cores are available on the system. This might not affect build times in every environment (for example, if GitHub Actions VMs are single core).

From the initial test run of this PR, we're seeing roughly 1x build speed on Linux, 3x on macOS, and 1.5x on Windows, compared to the same build step on a contemporaneous PR.