### PR TITLE
ci: Fix repo settings for self-hosted runners and debugging

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -60,7 +60,11 @@
    pushing bogus packages to NPM during CI testing from a fork
    - In a fork, set to a private name which differs from the production one
 
-## Optional Repo Secrets
- - `ENABLE_DEBUG`: Set to non-empty to enable debugging via SSH after a failure
- - `ENABLE_SELF_HOSTED`: Set to non-empty to enable self-hosted runners in the
-   build matrix
+## Repo Settings
+
+Each of these workflow features can be enabled by creating a "GitHub
+Environment" with the same name in your repo settings.  Forks will not have
+these enabled by default.
+
+ - `debug`: enable debugging via SSH after a failure
+ - `self_hosted`: enable self-hosted runners in the build matrix

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -18,7 +18,7 @@ on:
         type: string
 
       # If true, start a debug SSH server on failures.
-      ENABLE_DEBUG:
+      debug:
         required: false
         type: boolean
         default: false
@@ -64,4 +64,4 @@ jobs:
         uses: mxschmitt/action-tmate@v3.6
         with:
           limit-access-to-actor: true
-        if: failure() && inputs.ENABLE_DEBUG
+        if: failure() && inputs.debug

--- a/.github/workflows/build-matrix.json
+++ b/.github/workflows/build-matrix.json
@@ -21,7 +21,7 @@
     }
   ],
 
-  "comment2": "runners hosted by the owner, enabled by the ENABLE_SELF_HOSTED secret being set on the repo",
+  "comment2": "runners hosted by the owner, enabled by the 'self_hosted' environment being created on the repo",
   "selfHosted": [
     {
       "os": "self-hosted-linux-arm64",

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,21 +15,21 @@ on:
       ref:
         required: true
         type: string
+      # If true, start a debug SSH server on failures.
+      debug:
+        required: false
+        type: boolean
+        default: false
+      # If true, enable self-hosted runners in the build matrix.
+      self_hosted:
+        required: false
+        type: boolean
+        default: false
+
     secrets:
       # The GITHUB_TOKEN name is reserved, but not passed through implicitly.
       # So we call our secret parameter simply TOKEN.
       TOKEN:
-        required: false
-
-      # These below are not actual secrets, but secrets are the only place to
-      # keep repo-specific configs that make this project friendlier to forks
-      # and easier to debug.
-
-      # If non-empty, start a debug SSH server on failures.
-      ENABLE_DEBUG:
-        required: false
-      # If non-empty, enable self-hosted runners in the build matrix.
-      ENABLE_SELF_HOSTED:
         required: false
 
 # By default, run all commands in a bash shell.  On Windows, the default would
@@ -41,15 +41,14 @@ defaults:
 jobs:
   # Configure the build matrix based on inputs.  The list of objects in the
   # build matrix contents can't be changed by conditionals, but it can be
-  # computed by another job and deserialized.  This uses
-  # secrets.ENABLE_SELF_HOSTED to determine the build matrix, based on the
-  # metadata in build-matrix.json.
-  matrix_config:
+  # computed by another job and deserialized.  This uses inputs.self_hosted to
+  # determine the build matrix, based on the metadata in build-matrix.json.
+  build_matrix_config:
+    name: Matrix configuration
     runs-on: ubuntu-latest
     outputs:
       INCLUDE: ${{ steps.configure.outputs.INCLUDE }}
       OS: ${{ steps.configure.outputs.OS }}
-      ENABLE_DEBUG: ${{ steps.configure.outputs.ENABLE_DEBUG }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -59,11 +58,10 @@ jobs:
         id: configure
         shell: node {0}
         run: |
-          const enableDebug = "${{ secrets.ENABLE_DEBUG }}" != '';
-          const enableSelfHosted = "${{ secrets.ENABLE_SELF_HOSTED }}" != '';
+          const enableSelfHosted = ${{ inputs.self_hosted }};
 
-          // Use ENABLE_SELF_HOSTED to decide what the build matrix below
-          // should include.
+          // Use enableSelfHosted to decide what the build matrix below should
+          // include.
           const {hosted, selfHosted} = require("${{ github.workspace }}/.github/workflows/build-matrix.json");
           const include = enableSelfHosted ? hosted.concat(selfHosted) : hosted;
           const os = include.map((config) => config.os);
@@ -72,19 +70,16 @@ jobs:
           console.log(`::set-output name=INCLUDE::${ JSON.stringify(include) }`);
           console.log(`::set-output name=OS::${ JSON.stringify(os) }`);
 
-          // Output the debug flag directly.
-          console.log(`::set-output name=ENABLE_DEBUG::${ enableDebug }`);
-
           // Log the outputs, for the sake of debugging this script.
-          console.log({enableDebug, include, os});
+          console.log({enableSelfHosted, include, os});
 
   build:
-    needs: matrix_config
+    needs: build_matrix_config
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(needs.matrix_config.outputs.INCLUDE) }}
-        os: ${{ fromJSON(needs.matrix_config.outputs.OS) }}
+        include: ${{ fromJSON(needs.build_matrix_config.outputs.INCLUDE) }}
+        os: ${{ fromJSON(needs.build_matrix_config.outputs.OS) }}
         build_type: ["Debug", "Release"]
         lib_type: ["static", "shared"]
 
@@ -198,4 +193,4 @@ jobs:
         uses: mxschmitt/action-tmate@v3.6
         with:
           limit-access-to-actor: true
-        if: failure() && needs.matrix_config.outputs.ENABLE_DEBUG != ''
+        if: failure() && inputs.debug

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -22,6 +22,10 @@ on:
         required: False
 
 jobs:
+  settings:
+    name: Settings
+    uses: ./.github/workflows/settings.yaml
+
   lint:
     name: Lint
     uses: ./.github/workflows/lint.yaml
@@ -29,18 +33,21 @@ jobs:
       ref: ${{ github.event.inputs.ref || github.ref }}
 
   build_and_test:
-    needs: lint
+    needs: [lint, settings]
     name: Build and test
     uses: ./.github/workflows/build.yaml
     with:
       ref: ${{ github.event.inputs.ref || github.ref }}
+      self_hosted: ${{ needs.settings.outputs.self_hosted != '' }}
+      debug: ${{ needs.settings.outputs.debug != '' }}
 
   build_docs:
-    needs: lint
+    needs: [lint, settings]
     name: Build docs
     uses: ./.github/workflows/build-docs.yaml
     with:
       ref: ${{ github.event.inputs.ref || github.ref }}
+      debug: ${{ needs.settings.outputs.debug != '' }}
 
   official_docker_image:
     needs: lint

--- a/.github/workflows/settings.yaml
+++ b/.github/workflows/settings.yaml
@@ -1,0 +1,46 @@
+# Copyright 2022 Google LLC
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file or at
+# https://developers.google.com/open-source/licenses/bsd
+
+# A reusable workflow to extract settings from a repository.
+# To enable a setting, create a "GitHub Environment" with the same name.
+# This is a hack to enable per-repo settings that aren't copied to a fork.
+# Without this, test workflows for a fork would time out waiting for
+# self-hosted runners that the fork doesn't have.
+name: Settings
+
+# Runs when called from another workflow.
+on:
+  workflow_call:
+    outputs:
+      self_hosted:
+        description: "Enable jobs requiring a self-hosted runner."
+        value: ${{ jobs.settings.outputs.self_hosted }}
+      debug:
+        description: "Enable SSH debugging when a workflow fails."
+        value: ${{ jobs.settings.outputs.debug }}
+
+jobs:
+  settings:
+    runs-on: ubuntu-latest
+    outputs:
+      self_hosted: ${{ steps.settings.outputs.self_hosted }}
+      debug: ${{ steps.settings.outputs.debug }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - id: settings
+        run: |
+          environments=$(gh api /repos/${{ github.repository }}/environments)
+          for name in self_hosted debug; do
+            exists=$(echo $environments | jq ".environments[] | select(.name == \"$name\")")
+            if [[ "$exists" != "" ]]; then
+              echo "$name=true" >> $GITHUB_OUTPUT
+              echo "\"$name\" enabled."
+            else
+              echo "$name=" >> $GITHUB_OUTPUT
+              echo "\"$name\" disabled."
+            fi
+          done

--- a/.github/workflows/test-linux-distros.yaml
+++ b/.github/workflows/test-linux-distros.yaml
@@ -23,8 +23,8 @@ defaults:
 
 jobs:
   # Configure the build matrix based on files in the repo.
-  matrix_config:
-    name: Matrix config
+  docker_matrix_config:
+    name: Matrix configuration
     runs-on: ubuntu-latest
     outputs:
       MATRIX: ${{ steps.configure.outputs.MATRIX }}
@@ -51,13 +51,13 @@ jobs:
 
   # Build each dockerfile in parallel in a different CI job.
   build:
-    needs: matrix_config
+    needs: docker_matrix_config
     strategy:
       # Let other matrix entries complete, so we have all results on failure
       # instead of just the first failure.
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(needs.matrix_config.outputs.MATRIX) }}
+        include: ${{ fromJSON(needs.docker_matrix_config.outputs.MATRIX) }}
 
     name: ${{ matrix.os_name }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
The hack of using "secrets" to store per-repo settings was not working.  The main reason is that pull_request workflows don't have access to secrets no matter what you do.  So it was impossible to make this work for settings like "ENABLE_SELF_HOSTED" for PR tests.

This change replaces that old hack with a new one.  Now a repo owner must create a "GitHub Environment" with the name of the setting they want to enable.  Currently supported values are "self_hosted", to add self-hosted runners to the build/test matrix, and "debug", to start an SSH server for debugging when a workflow fails.