### PR TITLE
refactor: Rename common.h to macros.h, now that it only contains macros

### DIFF
--- a/packager/file/callback_file.cc
+++ b/packager/file/callback_file.cc
@@ -7,7 +7,7 @@
 #include "packager/file/callback_file.h"
 
 #include "glog/logging.h"
-#include "packager/common.h"
+#include "packager/macros.h"
 
 namespace shaka {
 

--- a/packager/file/file.h
+++ b/packager/file/file.h
@@ -11,8 +11,8 @@
 
 #include <string>
 
-#include "packager/common.h"
 #include "packager/file/public/buffer_callback_params.h"
+#include "packager/macros.h"
 #include "packager/status/status.h"
 
 namespace shaka {

--- a/packager/file/http_file.cc
+++ b/packager/file/http_file.cc
@@ -14,8 +14,8 @@
 #include "absl/strings/str_format.h"
 #include "glog/logging.h"
 
-#include "packager/common.h"
 #include "packager/file/thread_pool.h"
+#include "packager/macros.h"
 #include "packager/version/version.h"
 
 ABSL_FLAG(std::string,

--- a/packager/file/io_cache.h
+++ b/packager/file/io_cache.h
@@ -12,7 +12,7 @@
 #include <vector>
 
 #include "absl/synchronization/mutex.h"
-#include "packager/common.h"
+#include "packager/macros.h"
 
 namespace shaka {
 

--- a/packager/file/thread_pool.h
+++ b/packager/file/thread_pool.h
@@ -7,13 +7,12 @@
 #ifndef PACKAGER_FILE_THREAD_POOL_H_
 #define PACKAGER_FILE_THREAD_POOL_H_
 
-#include "packager/common.h"
-
 #include <functional>
 #include <queue>
 
 #include "absl/base/thread_annotations.h"
 #include "absl/synchronization/mutex.h"
+#include "packager/macros.h"
 
 namespace shaka {
 

--- a/packager/file/udp_options.cc
+++ b/packager/file/udp_options.cc
@@ -10,8 +10,8 @@
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_split.h"
 #include "glog/logging.h"
-#include "packager/common.h"
 #include "packager/kv_pairs/kv_pairs.h"
+#include "packager/macros.h"
 
 ABSL_FLAG(std::string,
           udp_interface_address,

--- a/packager/macros.h
+++ b/packager/macros.h
@@ -4,14 +4,12 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#ifndef PACKAGER_COMMON_H_
-#define PACKAGER_COMMON_H_
+#ifndef PACKAGER_MACROS_H_
+#define PACKAGER_MACROS_H_
 
 #include <type_traits>
 
 #include "absl/base/macros.h"
-
-namespace shaka {
 
 /// A macro to disable copying and assignment. Usage:
 /// class Foo {
@@ -34,6 +32,4 @@ namespace shaka {
 /// You can use the insertion operator to add specific logs to this.
 #define NOTIMPLEMENTED() LOG(ERROR) << "NOTIMPLEMENTED: "
 
-}  // namespace shaka
-
-#endif  // PACKAGER_COMMON_H_
+#endif  // PACKAGER_MACROS_H_

--- a/packager/status/status.cc
+++ b/packager/status/status.cc
@@ -8,7 +8,7 @@
 
 #include "absl/strings/str_format.h"
 #include "glog/logging.h"
-#include "packager/common.h"
+#include "packager/macros.h"
 
 namespace shaka {
 


### PR DESCRIPTION
Issue #1047 (CMake porting)