### PR TITLE
fix: Fix status library headers and move test

### DIFF
--- a/packager/status/CMakeLists.txt
+++ b/packager/status/CMakeLists.txt
@@ -15,6 +15,7 @@ if(LIBPACKAGER_SHARED)
 endif()
 
 add_executable(status_unittest
+    status_test_util_unittest.cc
     status_unittest.cc)
 target_link_libraries(status_unittest
     status

--- a/packager/status/status_macros.h
+++ b/packager/status/status_macros.h
@@ -7,7 +7,7 @@
 #ifndef PACKAGER_STATUS_MACROS_H_
 #define PACKAGER_STATUS_MACROS_H_
 
-#include "packager/status.h"
+#include "packager/status/status.h"
 
 // Evaluates an expression that produces a `Status`. If the status is not
 // ok, returns it from the current function.

--- a/packager/status/status_test_util.h
+++ b/packager/status/status_test_util.h
@@ -9,7 +9,7 @@
 
 #include <gtest/gtest.h>
 
-#include "packager/status.h"
+#include "packager/status/status.h"
 
 #define EXPECT_OK(val) EXPECT_EQ(shaka::Status::OK, (val))
 #define ASSERT_OK(val) ASSERT_EQ(shaka::Status::OK, (val))

--- a/packager/status/status_test_util_unittest.cc
+++ b/packager/status/status_test_util_unittest.cc
@@ -6,7 +6,7 @@
 
 #include <gtest/gtest-spi.h>
 
-#include "packager/status_test_util.h"
+#include "packager/status/status_test_util.h"
 
 namespace shaka {
 namespace media {


### PR DESCRIPTION
For some reason, the status util unittest was in media/base/ instead of status/

The broken headers in the status library were not obviously broken until media/base/ porting started, and they were used for the first time.

Issue #1047 (CMake porting)