### PR TITLE
ci: Fix docs build in GitHub Actions (#1109)

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -42,7 +42,7 @@ jobs:
         # NOTE: macos-10.15 is required for now, to work around issues with our
         # build system.  See related comments in
         # .github/workflows/custom-actions/build-packager/action.yaml
-        os: ["ubuntu-latest", "macos-10.15", "windows-latest", "self-hosted-linux-arm64"]
+        os: ["ubuntu-latest", "macos-10.15", "windows-2019", "self-hosted-linux-arm64"]
         build_type: ["Debug", "Release"]
         lib_type: ["static", "shared"]
         include:
@@ -56,7 +56,7 @@ jobs:
             target_arch: x64
             exe_ext: ""
             build_type_suffix: ""
-          - os: windows-latest
+          - os: windows-2019
             os_name: win
             target_arch: x64
             exe_ext: ".exe"

--- a/.github/workflows/custom-actions/build-docs/action.yaml
+++ b/.github/workflows/custom-actions/build-docs/action.yaml
@@ -17,7 +17,6 @@ runs:
         python3 -m pip install \
             sphinxcontrib.plantuml \
             recommonmark \
-            cloud_sptheme \
             breathe
         echo "::endgroup::"
 

--- a/.github/workflows/github_release.yaml
+++ b/.github/workflows/github_release.yaml
@@ -112,7 +112,7 @@ jobs:
     needs: [setup, lint, draft_release]
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest", "self-hosted-linux-arm64"]
+        os: ["ubuntu-latest", "macos-latest", "windows-2019", "self-hosted-linux-arm64"]
         build_type: ["Debug", "Release"]
         lib_type: ["static", "shared"]
         include:
@@ -126,7 +126,7 @@ jobs:
             target_arch: x64
             exe_ext: ""
             build_type_suffix: ""
-          - os: windows-latest
+          - os: windows-2019
             os_name: win
             target_arch: x64
             exe_ext: ".exe"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,7 +35,6 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.githubpages',
               'sphinxcontrib.plantuml',
               'recommonmark',
-              'cloud_sptheme.ext.table_styling',
               'breathe']
 
 # Breathe configurations.


### PR DESCRIPTION
The docs build in GitHub Actions broke with the release of jinja 3.1, which introduced a breaking change that broke the cloud_sptheme sphinx extension in use by our docs. That extension is not maintained any more, so there will be no upstream fix. See also
https://foss.heptapod.net/doc-utils/cloud_sptheme/-/issues/47

That extension adds support for table styling (see https://cloud-sptheme.readthedocs.io/en/latest/lib/cloud_sptheme.ext.table_styling.html), but we only appear to have one table in the docs currently (docs/source/options/segment_template_formatting.rst) and it does not use the options added by the cloud_sptheme extension.

Therefore the best fix for GitHub Actions and any other system running jinja 3.1 is to remove that extension from our config.

Backported from `cmake` branch to `main`.