### PR TITLE
ci: Use multiple cores in docker tests

### DIFF
--- a/packager/testing/test_dockers.sh
+++ b/packager/testing/test_dockers.sh
@@ -85,9 +85,9 @@ for DOCKER_FILE in ${SCRIPT_DIR}/dockers/*; do
   RAN_SOMETHING=1
   docker build -t ${CONTAINER} -f ${DOCKER_FILE} ${SCRIPT_DIR}/dockers/
   mkdir -p "${TEMP_BUILD_DIR}"
-  docker_run cmake -S . -B build/
-  docker_run make -C build/
-  docker_run bash -c "cd build && ctest -V"
+  docker_run cmake -S . -B build/ -DCMAKE_BUILD_TYPE=Debug
+  docker_run cmake --build build/ --config Debug --parallel
+  docker_run bash -c "cd build && ctest -C Debug -V"
   rm -rf "${TEMP_BUILD_DIR}"
 done
 


### PR DESCRIPTION
This seems to bring current docker build times in the cmake branch from 4-6 minutes down to 3-4 minutes.