### PR TITLE
ci: Disable parallel builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -128,7 +128,7 @@ jobs:
         # Visual Studio on Windows.  Note that the VS generator is what cmake
         # calls a "multi-configuration" generator, and so the desired build
         # type must be specified for Windows.
-        run: cmake --build build/ --config "${{ matrix.build_type }}" --parallel
+        run: cmake --build build/ --config "${{ matrix.build_type }}"
 
       - name: Test
         run: ctest -C "${{ matrix.build_type }}" -V --test-dir build/

--- a/packager/testing/test_dockers.sh
+++ b/packager/testing/test_dockers.sh
@@ -86,7 +86,7 @@ for DOCKER_FILE in ${SCRIPT_DIR}/dockers/*; do
   docker build -t ${CONTAINER} -f ${DOCKER_FILE} ${SCRIPT_DIR}/dockers/
   mkdir -p "${TEMP_BUILD_DIR}"
   docker_run cmake -S . -B build/ -DCMAKE_BUILD_TYPE=Debug
-  docker_run cmake --build build/ --config Debug --parallel
+  docker_run cmake --build build/ --config Debug
   docker_run bash -c "cd build && ctest -C Debug -V"
   rm -rf "${TEMP_BUILD_DIR}"
 done


### PR DESCRIPTION
This appears to fix some issues with crashing compilers on arm64 and docker builds.  This may be caused by resource constraints in those environments.