### PR TITLE
feat: Allow language code "und"

### DIFF
--- a/docs/source/options/stream_descriptors.rst
+++ b/docs/source/options/stream_descriptors.rst
@@ -49,7 +49,9 @@ These are the available fields:
 :language (lang):
 
     Optional value which contains a user-specified language tag. If specified,
-    this value overrides any language metadata in the input stream.
+    this value overrides any language metadata in the input stream. Invalid
+    language tags will be treated as 'und' which indicates the language is
+    undetermined.
 
 :output_format (format):
 

--- a/packager/media/base/language_utils.cc
+++ b/packager/media/base/language_utils.cc
@@ -133,7 +133,7 @@ std::string LanguageToISO_639_2(const std::string& language) {
   LOG(WARNING) << "No equivalent 3-letter language code for " << main_language;
   // This is probably a mistake on the part of the user and should be treated
   // as invalid input.
-  return "und";
+  return "qaa"; // Use a locally scoped ISO-639-2 code to denote invalid input.
 }
 
 }  // namespace shaka

--- a/packager/media/base/language_utils.cc
+++ b/packager/media/base/language_utils.cc
@@ -133,7 +133,7 @@ std::string LanguageToISO_639_2(const std::string& language) {
   LOG(WARNING) << "No equivalent 3-letter language code for " << main_language;
   // This is probably a mistake on the part of the user and should be treated
   // as invalid input.
-  return "qaa"; // Use a locally scoped ISO-639-2 code to denote invalid input.
+  return "und";
 }
 
 }  // namespace shaka

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -943,10 +943,10 @@ Status Packager::Initialize(
     // Update language to ISO_639_2 code if set.
     if (!copy.language.empty()) {
       copy.language = LanguageToISO_639_2(descriptor.language);
-      if (copy.language == "qaa") {
-        return Status(
-            error::INVALID_ARGUMENT,
-            "Unknown/invalid language specified: " + descriptor.language);
+      if (copy.language == "und" && descriptor.language != "und") {
+        LOG(WARNING)
+            << "Unknown/invalid language specified: " << descriptor.language
+            << ". Treat the language as undetermined.";
       }
     }
 

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -943,7 +943,7 @@ Status Packager::Initialize(
     // Update language to ISO_639_2 code if set.
     if (!copy.language.empty()) {
       copy.language = LanguageToISO_639_2(descriptor.language);
-      if (copy.language == "und") {
+      if (copy.language == "qaa") {
         return Status(
             error::INVALID_ARGUMENT,
             "Unknown/invalid language specified: " + descriptor.language);

--- a/packager/packager.h
+++ b/packager/packager.h
@@ -107,7 +107,9 @@ struct StreamDescriptor {
   /// parameter for segment names. If not specified, its value may be estimated.
   uint32_t bandwidth = 0;
   /// Optional value which contains a user-specified language tag. If specified,
-  /// this value overrides any language metadata in the input stream.
+  /// this value overrides any language metadata in the input stream. Invalid
+  /// language tags will be treated as 'und' which indicates the language is
+  /// undetermined.
   std::string language;
   /// Optional value for the index of the sub-stream to use. For some text
   /// formats, there are multiple "channels" in a single stream. This allows

--- a/packager/packager_test.cc
+++ b/packager/packager_test.cc
@@ -204,10 +204,9 @@ TEST_F(PackagerTest, UnrecognizedAudioLanguage) {
   stream_descriptors.push_back(stream_descriptor);
 
   Packager packager;
-  auto status = packager.Initialize(SetupPackagingParams(), stream_descriptors);
-  ASSERT_EQ(error::INVALID_ARGUMENT, status.error_code());
-  EXPECT_THAT(status.error_message(),
-              HasSubstr("Unknown/invalid language specified"));
+  ASSERT_EQ(Status::OK,
+            packager.Initialize(SetupPackagingParams(), stream_descriptors));
+  ASSERT_EQ(Status::OK, packager.Run());
 }
 
 TEST_F(PackagerTest, AudioLanguageCode_und) {

--- a/packager/packager_test.cc
+++ b/packager/packager_test.cc
@@ -186,6 +186,53 @@ TEST_F(PackagerTest, DuplicatedSegmentTemplates) {
               HasSubstr("duplicated segment templates"));
 }
 
+TEST_F(PackagerTest, UnrecognizedAudioLanguage) {
+  std::vector<StreamDescriptor> stream_descriptors;
+  StreamDescriptor stream_descriptor;
+
+  stream_descriptor.input = kTestFile;
+  stream_descriptor.stream_selector = "video";
+  stream_descriptor.output = GetFullPath(kOutputVideo);
+  stream_descriptor.segment_template = GetFullPath(kOutputVideoTemplate);
+  stream_descriptors.push_back(stream_descriptor);
+
+  stream_descriptor.input = kTestFile;
+  stream_descriptor.stream_selector = "audio";
+  stream_descriptor.output = GetFullPath(kOutputAudio);
+  stream_descriptor.segment_template = GetFullPath(kOutputAudioTemplate);
+  stream_descriptor.language = "martian";
+  stream_descriptors.push_back(stream_descriptor);
+
+  Packager packager;
+  auto status = packager.Initialize(SetupPackagingParams(), stream_descriptors);
+  ASSERT_EQ(error::INVALID_ARGUMENT, status.error_code());
+  EXPECT_THAT(status.error_message(),
+              HasSubstr("Unknown/invalid language specified"));
+}
+
+TEST_F(PackagerTest, AudioLanguageCode_und) {
+  std::vector<StreamDescriptor> stream_descriptors;
+  StreamDescriptor stream_descriptor;
+
+  stream_descriptor.input = kTestFile;
+  stream_descriptor.stream_selector = "video";
+  stream_descriptor.output = GetFullPath(kOutputVideo);
+  stream_descriptor.segment_template = GetFullPath(kOutputVideoTemplate);
+  stream_descriptors.push_back(stream_descriptor);
+
+  stream_descriptor.input = kTestFile;
+  stream_descriptor.stream_selector = "audio";
+  stream_descriptor.output = GetFullPath(kOutputAudio);
+  stream_descriptor.segment_template = GetFullPath(kOutputAudioTemplate);
+  stream_descriptor.language = "und";
+  stream_descriptors.push_back(stream_descriptor);
+
+  Packager packager;
+  ASSERT_EQ(Status::OK,
+            packager.Initialize(SetupPackagingParams(), stream_descriptors));
+  ASSERT_EQ(Status::OK, packager.Run());
+}
+
 TEST_F(PackagerTest, SegmentAlignedAndSubsegmentNotAligned) {
   auto packaging_params = SetupPackagingParams();
   packaging_params.chunking_params.segment_sap_aligned = true;


### PR DESCRIPTION
This allows the stream descriptor "language" to be specified as "und".

In this change, the convention of using return value "und" to indicate invalid language code in function LanguageToISO_639_2 has been changed to using "qaa" which is a locally scoped code per ISO-639 for the same purpose.

Closes #1161