### PR TITLE
fix: Prevent crash in GetEarliestTimestamp() if periods are empty

### DIFF
--- a/packager/mpd/base/mpd_builder.cc
+++ b/packager/mpd/base/mpd_builder.cc
@@ -342,6 +342,8 @@ float MpdBuilder::GetStaticMpdDuration() {
 bool MpdBuilder::GetEarliestTimestamp(double* timestamp_seconds) {
   DCHECK(timestamp_seconds);
   DCHECK(!periods_.empty());
+  if (periods_.empty())
+    return false;    
   double timestamp = 0;
   double earliest_timestamp = -1;
   // TODO(kqyang): This is used to set availabilityStartTime. We may consider

--- a/packager/mpd/base/mpd_builder.cc
+++ b/packager/mpd/base/mpd_builder.cc
@@ -343,7 +343,7 @@ bool MpdBuilder::GetEarliestTimestamp(double* timestamp_seconds) {
   DCHECK(timestamp_seconds);
   DCHECK(!periods_.empty());
   if (periods_.empty())
-    return false;    
+    return false;
   double timestamp = 0;
   double earliest_timestamp = -1;
   // TODO(kqyang): This is used to set availabilityStartTime. We may consider


### PR DESCRIPTION
While I have not yet found why the periods are empty, this will prevent shaka from seg faulting

Fixes #1172