### PR TITLE
docs: Update build_instructions.md to point to the `main` branch.

### DIFF
--- a/docs/source/build_instructions.md
+++ b/docs/source/build_instructions.md
@@ -117,7 +117,7 @@ dependencies.
 
 ```shell
 gclient config https://github.com/shaka-project/shaka-packager.git --name=src --unmanaged
-gclient sync
+gclient sync -r main
 ```
 
 To sync to a particular commit or version, add the '-r \<revision\>' flag to


### PR DESCRIPTION
The default branch is `main`, not `master`. Indicate this on the documentation as its' not obvious.

Fixes #1060