### PR TITLE
fix: Don't close upstream on HttpFile::Flush

### DIFF
--- a/packager/file/http_file.cc
+++ b/packager/file/http_file.cc
@@ -243,6 +243,7 @@ int64_t HttpFile::Read(void* buffer, uint64_t length) {
 }
 
 int64_t HttpFile::Write(const void* buffer, uint64_t length) {
+  DCHECK(!upload_cache_.closed());
   VLOG(2) << "Writing to " << url_ << ", length=" << length;
   return upload_cache_.Write(buffer, length);
 }
@@ -253,7 +254,8 @@ int64_t HttpFile::Size() {
 }
 
 bool HttpFile::Flush() {
-  upload_cache_.Close();
+  // Wait for curl to read any data we may have buffered.
+  upload_cache_.WaitUntilEmptyOrClosed();
   return true;
 }
 


### PR DESCRIPTION
Closing the upstream on flush will effectively terminate the ongoing curl connection. This means that we would need re-establish the connection in order to resume writing, this is not what we want. In the spirit of the documentation of File::Flush

```c++
/// Flush the file so that recently written data will survive an 
/// application crash (but not necessarily an OS crash). For 
/// instance, in LocalFile the data is flushed into the OS but not 
/// necessarily to disk.
```

We will instead wait for the curl thread to finish consuming what ever might be in the upload cache, but leave the connection open for subsequent writes.

Fixes #1196