### PR TITLE
test: Fix OpenSUSE docker build

### DIFF
--- a/packager/testing/dockers/OpenSUSE_Dockerfile
+++ b/packager/testing/dockers/OpenSUSE_Dockerfile
@@ -1,12 +1,15 @@
-# Older versions of OpenSUSE (like leap 15) have compilers too old for C++17.
-# Tumbleweed is a rolling release system, but that's our only option now.
-FROM opensuse/tumbleweed:latest
+FROM opensuse/leap:15.5
 
 # Install utilities, libraries, and dev tools.
 RUN zypper in -y \
         curl which \
         c-ares-devel \
-        cmake gcc-c++ git python3
+        cmake gcc9-c++ git python3
+
+# OpenSuse 15 doesn't have the required gcc 9+ by default, but we can install
+# it as gcc9 and symlink it.
+RUN ln -s g++-9 /usr/bin/g++
+RUN ln -s gcc-9 /usr/bin/gcc
 
 # Build and run this docker by mapping shaka-packager with
 # -v "shaka-packager:/shaka-packager".


### PR DESCRIPTION
Using a rolling release of OpenSUSE was unstable.  But there is another way around the old compiler in OpenSUSE 15.  This upgrades the compiler while staying on a stable release of the OS.