### PR TITLE
fix: Fix compilation on Arch Linux

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -103,7 +103,7 @@ jobs:
         # NOTE: cmake is already installed in GitHub Actions VMs, but not
         # necessarily in a self-hosted runner.
         run: |
-          sudo apt install -y \
+          sudo apt update && sudo apt install -y \
               cmake \
               libc-ares-dev
 

--- a/packager/CMakeLists.txt
+++ b/packager/CMakeLists.txt
@@ -19,6 +19,8 @@ if(MSVC)
   add_compile_options(/wd4324)
   # Silence a warning about STL types in exported classes.
   add_compile_options(/wd4251)
+  # Silence a warning about constant conditional expressions.
+  add_compile_options(/wd4127)
 
   # Packager's macro for Windows-specific code.
   add_definitions(-DOS_WIN)

--- a/packager/file/io_cache.h
+++ b/packager/file/io_cache.h
@@ -69,13 +69,13 @@ class IoCache {
 
   const uint64_t cache_size_;
   absl::Mutex mutex_;
-  absl::CondVar read_event_ GUARDED_BY(mutex_);
-  absl::CondVar write_event_ GUARDED_BY(mutex_);
-  std::vector<uint8_t> circular_buffer_ GUARDED_BY(mutex_);
-  const uint8_t* end_ptr_ GUARDED_BY(mutex_);
-  uint8_t* r_ptr_ GUARDED_BY(mutex_);
-  uint8_t* w_ptr_ GUARDED_BY(mutex_);
-  bool closed_ GUARDED_BY(mutex_);
+  absl::CondVar read_event_ ABSL_GUARDED_BY(mutex_);
+  absl::CondVar write_event_ ABSL_GUARDED_BY(mutex_);
+  std::vector<uint8_t> circular_buffer_ ABSL_GUARDED_BY(mutex_);
+  const uint8_t* end_ptr_ ABSL_GUARDED_BY(mutex_);
+  uint8_t* r_ptr_ ABSL_GUARDED_BY(mutex_);
+  uint8_t* w_ptr_ ABSL_GUARDED_BY(mutex_);
+  bool closed_ ABSL_GUARDED_BY(mutex_);
 
   DISALLOW_COPY_AND_ASSIGN(IoCache);
 };

--- a/packager/file/memory_file.cc
+++ b/packager/file/memory_file.cc
@@ -101,9 +101,9 @@ class FileSystem {
   FileSystem() = default;
 
   // Filename to file data map.
-  std::map<std::string, std::vector<uint8_t>> files_ GUARDED_BY(mutex_);
+  std::map<std::string, std::vector<uint8_t>> files_ ABSL_GUARDED_BY(mutex_);
   // Filename to file open modes map.
-  std::map<std::string, std::string> open_files_ GUARDED_BY(mutex_);
+  std::map<std::string, std::string> open_files_ ABSL_GUARDED_BY(mutex_);
 
   absl::Mutex mutex_;
 };

--- a/packager/file/thread_pool.h
+++ b/packager/file/thread_pool.h
@@ -42,10 +42,10 @@ class ThreadPool {
   void ThreadMain();
 
   absl::Mutex mutex_;
-  absl::CondVar tasks_available_ GUARDED_BY(mutex_);
-  std::queue<Task> tasks_ GUARDED_BY(mutex_);
-  size_t num_idle_threads_ GUARDED_BY(mutex_);
-  bool terminated_ GUARDED_BY(mutex_);
+  absl::CondVar tasks_available_ ABSL_GUARDED_BY(mutex_);
+  std::queue<Task> tasks_ ABSL_GUARDED_BY(mutex_);
+  size_t num_idle_threads_ ABSL_GUARDED_BY(mutex_);
+  bool terminated_ ABSL_GUARDED_BY(mutex_);
 
   DISALLOW_COPY_AND_ASSIGN(ThreadPool);
 };

--- a/packager/file/threaded_io_file.h
+++ b/packager/file/threaded_io_file.h
@@ -62,11 +62,11 @@ class ThreadedIoFile : public File {
   std::atomic<int64_t> internal_file_error_;
 
   absl::Mutex flush_mutex_;
-  bool flushing_ GUARDED_BY(flush_mutex_);
-  bool flush_complete_ GUARDED_BY(flush_mutex_);
+  bool flushing_ ABSL_GUARDED_BY(flush_mutex_);
+  bool flush_complete_ ABSL_GUARDED_BY(flush_mutex_);
 
   absl::Mutex task_exited_mutex_;
-  bool task_exited_ GUARDED_BY(task_exited_mutex_);
+  bool task_exited_ ABSL_GUARDED_BY(task_exited_mutex_);
 
   DISALLOW_COPY_AND_ASSIGN(ThreadedIoFile);
 };

--- a/packager/media/base/buffer_writer.h
+++ b/packager/media/base/buffer_writer.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_BASE_BUFFER_WRITER_H_
 #define PACKAGER_MEDIA_BASE_BUFFER_WRITER_H_
 
+#include <cstdint>
 #include <vector>
 
 #include "packager/macros.h"

--- a/packager/media/base/fourccs.h
+++ b/packager/media/base/fourccs.h
@@ -5,6 +5,7 @@
 #ifndef PACKAGER_MEDIA_BASE_FOURCCS_H_
 #define PACKAGER_MEDIA_BASE_FOURCCS_H_
 
+#include <cstdint>
 #include <string>
 
 namespace shaka {

--- a/packager/media/base/id3_tag.h
+++ b/packager/media/base/id3_tag.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_BASE_ID3_TAG_H_
 #define PACKAGER_MEDIA_BASE_ID3_TAG_H_
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/packager/media/base/producer_consumer_queue.h
+++ b/packager/media/base/producer_consumer_queue.h
@@ -126,11 +126,13 @@ class ProducerConsumerQueue {
 
   mutable absl::Mutex mutex_;
   size_t head_pos_ ABSL_GUARDED_BY(mutex_);  // Head position.
-  std::deque<T> q_ ABSL_GUARDED_BY(mutex_);  // Internal queue holding the elements.
+  std::deque<T> q_
+      ABSL_GUARDED_BY(mutex_);  // Internal queue holding the elements.
   absl::CondVar not_empty_cv_ ABSL_GUARDED_BY(mutex_);
   absl::CondVar not_full_cv_ ABSL_GUARDED_BY(mutex_);
   absl::CondVar new_element_cv_ ABSL_GUARDED_BY(mutex_);
-  bool stop_requested_ ABSL_GUARDED_BY(mutex_);  // True after Stop has been called.
+  bool stop_requested_
+      ABSL_GUARDED_BY(mutex_);  // True after Stop has been called.
 
   DISALLOW_COPY_AND_ASSIGN(ProducerConsumerQueue);
 };

--- a/packager/media/base/producer_consumer_queue.h
+++ b/packager/media/base/producer_consumer_queue.h
@@ -125,12 +125,12 @@ class ProducerConsumerQueue {
   const size_t capacity_;  // Maximum number of elements; zero means unlimited.
 
   mutable absl::Mutex mutex_;
-  size_t head_pos_ GUARDED_BY(mutex_);  // Head position.
-  std::deque<T> q_ GUARDED_BY(mutex_);  // Internal queue holding the elements.
-  absl::CondVar not_empty_cv_ GUARDED_BY(mutex_);
-  absl::CondVar not_full_cv_ GUARDED_BY(mutex_);
-  absl::CondVar new_element_cv_ GUARDED_BY(mutex_);
-  bool stop_requested_ GUARDED_BY(mutex_);  // True after Stop has been called.
+  size_t head_pos_ ABSL_GUARDED_BY(mutex_);  // Head position.
+  std::deque<T> q_ ABSL_GUARDED_BY(mutex_);  // Internal queue holding the elements.
+  absl::CondVar not_empty_cv_ ABSL_GUARDED_BY(mutex_);
+  absl::CondVar not_full_cv_ ABSL_GUARDED_BY(mutex_);
+  absl::CondVar new_element_cv_ ABSL_GUARDED_BY(mutex_);
+  bool stop_requested_ ABSL_GUARDED_BY(mutex_);  // True after Stop has been called.
 
   DISALLOW_COPY_AND_ASSIGN(ProducerConsumerQueue);
 };

--- a/packager/media/base/proto_json_util.cc
+++ b/packager/media/base/proto_json_util.cc
@@ -18,7 +18,7 @@ std::string MessageToJsonString(const google::protobuf::Message& message) {
   json_print_options.preserve_proto_field_names = true;
 
   std::string result;
-  GOOGLE_CHECK_OK(google::protobuf::util::MessageToJsonString(
+  ABSL_CHECK_OK(google::protobuf::util::MessageToJsonString(
       message, &result, json_print_options));
   return result;
 }

--- a/packager/media/chunking/sync_point_queue.h
+++ b/packager/media/chunking/sync_point_queue.h
@@ -60,7 +60,7 @@ class SyncPointQueue {
   std::shared_ptr<const CueEvent> PromoteAtNoLocking(double time_in_seconds);
 
   absl::Mutex mutex_;
-  absl::CondVar sync_condition_ GUARDED_BY(mutex_);
+  absl::CondVar sync_condition_ ABSL_GUARDED_BY(mutex_);
   size_t thread_count_ = 0;
   size_t waiting_thread_count_ = 0;
   bool cancelled_ = false;

--- a/packager/media/test/test_web_server.h
+++ b/packager/media/test/test_web_server.h
@@ -37,10 +37,10 @@ class TestWebServer {
   };
 
   absl::Mutex mutex_;
-  TestWebServerStatus status_ GUARDED_BY(mutex_);
-  absl::CondVar started_ GUARDED_BY(mutex_);
-  absl::CondVar stop_ GUARDED_BY(mutex_);
-  bool stopped_ GUARDED_BY(mutex_);
+  TestWebServerStatus status_ ABSL_GUARDED_BY(mutex_);
+  absl::CondVar started_ ABSL_GUARDED_BY(mutex_);
+  absl::CondVar stop_ ABSL_GUARDED_BY(mutex_);
+  bool stopped_ ABSL_GUARDED_BY(mutex_);
 
   // Connections to be handled again later, mapped to the time at which we
   // should handle them again.  We can't block the server thread directly to

--- a/packager/testing/test_dockers.sh
+++ b/packager/testing/test_dockers.sh
@@ -83,7 +83,7 @@ for DOCKER_FILE in ${SCRIPT_DIR}/dockers/*; do
   CONTAINER="$( echo "packager_test_${OS_NAME}" | tr A-Z a-z )"
 
   RAN_SOMETHING=1
-  docker build -t ${CONTAINER} -f ${DOCKER_FILE} ${SCRIPT_DIR}/dockers/
+  docker build --pull -t ${CONTAINER} -f ${DOCKER_FILE} ${SCRIPT_DIR}/dockers/
   mkdir -p "${TEMP_BUILD_DIR}"
   docker_run cmake -S . -B build/ -DCMAKE_BUILD_TYPE=Debug
   docker_run cmake --build build/ --config Debug

--- a/packager/third_party/abseil-cpp/CMakeLists.txt
+++ b/packager/third_party/abseil-cpp/CMakeLists.txt
@@ -13,10 +13,5 @@ set(ABSL_PROPAGATE_CXX_STD ON)
 # for one in the system.
 set(ABSL_USE_EXTERNAL_GOOGLETEST ON)
 
-if(MSVC)
-  # Disable warnings about constant conditional expressions
-  add_compile_options(/wd4127)
-endif()
-
 # With these set in scope of this folder, load the library's own CMakeLists.txt.
 add_subdirectory(source)

--- a/packager/third_party/abseil-cpp/CMakeLists.txt
+++ b/packager/third_party/abseil-cpp/CMakeLists.txt
@@ -13,5 +13,10 @@ set(ABSL_PROPAGATE_CXX_STD ON)
 # for one in the system.
 set(ABSL_USE_EXTERNAL_GOOGLETEST ON)
 
+if(MSVC)
+  # Disable warnings about constant conditional expressions
+  add_compile_options(/wd4127)
+endif()
+
 # With these set in scope of this folder, load the library's own CMakeLists.txt.
 add_subdirectory(source)

--- a/packager/third_party/abseil-cpp/CMakeLists.txt
+++ b/packager/third_party/abseil-cpp/CMakeLists.txt
@@ -13,10 +13,5 @@ set(ABSL_PROPAGATE_CXX_STD ON)
 # for one in the system.
 set(ABSL_USE_EXTERNAL_GOOGLETEST ON)
 
-if(MSVC)
-  # Silence warning about signed/unsigned mismatch in comparison
-  add_compile_options(/wd4018)
-endif()
-
 # With these set in scope of this folder, load the library's own CMakeLists.txt.
 add_subdirectory(source)

--- a/packager/third_party/abseil-cpp/CMakeLists.txt
+++ b/packager/third_party/abseil-cpp/CMakeLists.txt
@@ -13,5 +13,10 @@ set(ABSL_PROPAGATE_CXX_STD ON)
 # for one in the system.
 set(ABSL_USE_EXTERNAL_GOOGLETEST ON)
 
+if(MSVC)
+  # Silence warning about signed/unsigned mismatch in comparison
+  add_compile_options(/wd4018)
+endif()
+
 # With these set in scope of this folder, load the library's own CMakeLists.txt.
 add_subdirectory(source)

--- a/packager/third_party/protobuf/CMakeLists.txt
+++ b/packager/third_party/protobuf/CMakeLists.txt
@@ -36,6 +36,8 @@ if(MSVC)
     /wd4100  # unreferenced formal parameter
     # src/google/protobuf/text_format.cc
     /wd4805  # unsafe mix of type bool and uint64_t in operation
+    # src/google/protobuf/compiler/cpp/field.cc via absl/log/internal/check_op.h
+    /wd4018  # signed/unsigned mismatch
   )
 else()
   add_compile_options(

--- a/packager/third_party/protobuf/CMakeLists.txt
+++ b/packager/third_party/protobuf/CMakeLists.txt
@@ -34,6 +34,8 @@ if(MSVC)
     /wd4141  # multiple inline keywords
     # src/google/protobuf/util/message_differencer.h
     /wd4100  # unreferenced formal parameter
+    # src/google/protobuf/text_format.cc
+    /wd4805  # unsafe mix of type bool and uint64_t in operation
   )
 else()
   add_compile_options(

--- a/packager/third_party/protobuf/CMakeLists.txt
+++ b/packager/third_party/protobuf/CMakeLists.txt
@@ -54,6 +54,12 @@ else()
     -Wno-unused-parameter
     # There are also redundant move calls.
     -Wno-redundant-move
+    # There are ignored qualifiers.
+    -Wno-ignored-qualifiers
+    # There are attributes that cannot be honored.
+    -Wno-attributes
+    # There are implicit fallthroughs.
+    -Wno-implicit-fallthrough
   )
 endif()
 

--- a/packager/version/version.cc
+++ b/packager/version/version.cc
@@ -45,7 +45,7 @@ class Version {
   Version& operator=(const Version&) = delete;
 
   absl::Mutex mutex_;
-  std::string version_ GUARDED_BY(mutex_);
+  std::string version_ ABSL_GUARDED_BY(mutex_);
 };
 
 }  // namespace


### PR DESCRIPTION
 - Update protobuf to v23.4, to fix the cstdint error on Arch Linux, and make some related changes:
   - Silence additional compiler warnings for the new protobuf
 - Update absl to 20230125.3, to support the protobuf update, and make some related changes:
   - Silence additional compiler warnings for the new protobuf
   - Replace GOOGLE_CHECK_OK with ABSL_CHECK_OK
   - Replace GUARDED_BY with ABSL_GUARDED_BY
 - Update other instances of cstdint missing in our own code
 - Always pull the latest docker images, to avoid stale results when your workstation has pulled an older image at the same label