### PR TITLE
chore: Revert to upstream mongoose

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -33,4 +33,4 @@
 	url = https://github.com/protocolbuffers/protobuf
 [submodule "packager/third_party/mongoose/source"]
 	path = packager/third_party/mongoose/source
-	url = https://github.com/joeyparrish/mongoose
+	url = https://github.com/cesanta/mongoose


### PR DESCRIPTION
Since https://github.com/cesanta/mongoose/issues/2300 was closed, revert to upstream mongoose, specifically the most recent tag "7.11"