### PR TITLE
WIP: Update build documentation and workflows

### DIFF
--- a/.github/workflows/build-matrix.json
+++ b/.github/workflows/build-matrix.json
@@ -5,19 +5,22 @@
       "os": "ubuntu-latest",
       "os_name": "linux",
       "target_arch": "x64",
-      "exe_ext": ""
+      "exe_ext": "",
+      "generator": "Ninja"
     },
     {
       "os": "macos-latest",
       "os_name": "osx",
       "target_arch": "x64",
-      "exe_ext": ""
+      "exe_ext": "",
+      "generator": "Ninja"
     },
     {
       "os": "windows-latest",
       "os_name": "win",
       "target_arch": "x64",
-      "exe_ext": ".exe"
+      "exe_ext": ".exe",
+      "generator": ""
     }
   ],
 
@@ -27,7 +30,9 @@
       "os": "self-hosted-linux-arm64",
       "os_name": "linux",
       "target_arch": "arm64",
-      "exe_ext": ""
+      "exe_ext": "",
+      "generator": "Ninja",
+      "low_mem": "yes"
     }
   ]
 }

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -100,12 +100,19 @@ jobs:
 
       - name: Install Linux deps
         if: runner.os == 'Linux'
-        # NOTE: cmake is already installed in GitHub Actions VMs, but not
+        # NOTE: CMake is already installed in GitHub Actions VMs, but not
         # necessarily in a self-hosted runner.
         run: |
           sudo apt update && sudo apt install -y \
               cmake \
-              libc-ares-dev
+              libc-ares-dev \
+              ninja-build
+
+      - name: Install Mac deps
+        if: runner.os == 'macOS'
+        # NOTE: GitHub Action VMs do not install ninja by default.
+        run: |
+          brew install ninja
 
       - name: Generate build files
         run: |
@@ -115,6 +122,18 @@ jobs:
             LIBPACKAGER_SHARED="ON"
           else
             LIBPACKAGER_SHARED="OFF"
+          fi
+
+          # If set, override the default generator for the platform.
+          # Not every entry in the build matrix config defines this.
+          # If this is blank, CMake will choose the default generator.
+          export CMAKE_GENERATOR="${{ matrix.generator }}"
+
+          # If set, configure the build to restrict parallel operations.
+          # This helps us avoid the compiler failing due to a lack of RAM
+          # on our arm64 build devices (4GB RAM shared among 6 CPUs).
+          if [[ "${{ matrix.low_mem }}" != "" ]]; then
+            export PACKAGER_LOW_MEMORY_BUILD=yes
           fi
 
           cmake \
@@ -128,7 +147,7 @@ jobs:
         # Visual Studio on Windows.  Note that the VS generator is what cmake
         # calls a "multi-configuration" generator, and so the desired build
         # type must be specified for Windows.
-        run: cmake --build build/ --config "${{ matrix.build_type }}"
+        run: cmake --build build/ --config "${{ matrix.build_type }}" --parallel
 
       - name: Test
         run: ctest -C "${{ matrix.build_type }}" -V --test-dir build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN apk add --no-cache \
 WORKDIR shaka-packager
 COPY . /shaka-packager/
 RUN mkdir build
-RUN cmake -S . -B build
-RUN make -C build
+RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -G Ninja
+RUN cmake --build build/ --config Debug --parallel
 
 # Copy only result binaries to our final image.
 FROM alpine:3.12

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.12 as builder
 RUN apk add --no-cache \
         bash curl \
         bsd-compat-headers c-ares-dev linux-headers \
-        build-base cmake git python3
+        build-base cmake git ninja python3
 
 # Build shaka-packager from the current directory, rather than what has been
 # merged.

--- a/packager/policies.cmake
+++ b/packager/policies.cmake
@@ -29,3 +29,13 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     message(FATAL_ERROR "GCC version must be at least 9! (Found ${CMAKE_CXX_COMPILER_VERSION})")
   endif()
 endif()
+
+# If the environment variable PACKAGER_LOW_MEMORY_BUILD is defined, limit the
+# number of parallel processes.  This is used in our workflow to keep our arm64
+# builds from failing.  There, we only have 4GB RAM to share among 6 CPUs.
+# NOTE: This only affects CMake's Ninja generator.
+if(DEFINED ENV{PACKAGER_LOW_MEMORY_BUILD})
+  set_property(GLOBAL PROPERTY JOB_POOLS
+               link_jobs=1)
+  set(CMAKE_JOB_POOL_LINK link_jobs)
+endif()

--- a/packager/testing/dockers/Alpine_Dockerfile
+++ b/packager/testing/dockers/Alpine_Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.12
 RUN apk add --no-cache \
         bash curl \
         bsd-compat-headers c-ares-dev linux-headers \
-        build-base cmake git python3
+        build-base cmake git ninja python3
 
 # Build and run this docker by mapping shaka-packager with
 # -v "shaka-packager:/shaka-packager".

--- a/packager/testing/dockers/ArchLinux_Dockerfile
+++ b/packager/testing/dockers/ArchLinux_Dockerfile
@@ -4,7 +4,7 @@ FROM archlinux:latest
 RUN pacman -Sy --needed --noconfirm \
         core/which \
         c-ares \
-        cmake gcc git make python3
+        cmake gcc git ninja python3
 
 # Build and run this docker by mapping shaka-packager with
 # -v "shaka-packager:/shaka-packager".

--- a/packager/testing/dockers/CentOS_Dockerfile
+++ b/packager/testing/dockers/CentOS_Dockerfile
@@ -10,7 +10,7 @@ RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|
 RUN yum install -y \
         which \
         c-ares-devel libatomic \
-        cmake gcc-toolset-9-gcc gcc-toolset-9-gcc-c++ git python3
+        cmake gcc-toolset-9-gcc gcc-toolset-9-gcc-c++ git ninja-build python3
 
 # CentOS 8 is old, and the g++ version installed doesn't automatically link the
 # C++ filesystem library as it should.  Activate a newer dev environment.

--- a/packager/testing/dockers/Debian_Dockerfile
+++ b/packager/testing/dockers/Debian_Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y apt-utils
 RUN apt-get install -y \
         curl \
         libc-ares-dev \
-        build-essential cmake git python3
+        build-essential cmake git ninja-build python3
 
 # Build and run this docker by mapping shaka-packager with
 # -v "shaka-packager:/shaka-packager".

--- a/packager/testing/dockers/Fedora_Dockerfile
+++ b/packager/testing/dockers/Fedora_Dockerfile
@@ -4,7 +4,7 @@ FROM fedora:34
 RUN yum install -y \
         which \
         c-ares-devel libatomic \
-        cmake gcc-c++ git python3
+        cmake gcc-c++ git ninja-build python3
 
 # Build and run this docker by mapping shaka-packager with
 # -v "shaka-packager:/shaka-packager".

--- a/packager/testing/dockers/OpenSUSE_Dockerfile
+++ b/packager/testing/dockers/OpenSUSE_Dockerfile
@@ -4,7 +4,7 @@ FROM opensuse/leap:15.5
 RUN zypper in -y \
         curl which \
         c-ares-devel \
-        cmake gcc9-c++ git python3
+        cmake gcc9-c++ git ninja python3
 
 # OpenSuse 15 doesn't have the required gcc 9+ by default, but we can install
 # it as gcc9 and symlink it.

--- a/packager/testing/dockers/Ubuntu_Dockerfile
+++ b/packager/testing/dockers/Ubuntu_Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y apt-utils
 RUN apt-get install -y \
         curl \
         libc-ares-dev \
-        build-essential cmake git python3
+        build-essential cmake git ninja-build python3
 
 # Build and run this docker by mapping shaka-packager with
 # -v "shaka-packager:/shaka-packager".

--- a/packager/testing/test_dockers.sh
+++ b/packager/testing/test_dockers.sh
@@ -85,8 +85,8 @@ for DOCKER_FILE in ${SCRIPT_DIR}/dockers/*; do
   RAN_SOMETHING=1
   docker build --pull -t ${CONTAINER} -f ${DOCKER_FILE} ${SCRIPT_DIR}/dockers/
   mkdir -p "${TEMP_BUILD_DIR}"
-  docker_run cmake -S . -B build/ -DCMAKE_BUILD_TYPE=Debug
-  docker_run cmake --build build/ --config Debug
+  docker_run cmake -S . -B build/ -DCMAKE_BUILD_TYPE=Debug -G Ninja
+  docker_run cmake --build build/ --config Debug --parallel
   docker_run bash -c "cd build && ctest -C Debug -V"
   rm -rf "${TEMP_BUILD_DIR}"
 done


### PR DESCRIPTION
This updates build documentation, and also updates our workflows to match our recommendations for CMake builds on all platforms.

Our generator recommendations (Ninja on Linux & Mac) also enable safe use of parallel builds, which significantly speed up our workflows.

Parallel builds are **NOT** recommended with Unix Makefiles due to the use of excessive RAM during parallel linking.