### PR TITLE
test: Fix data directory computation

### DIFF
--- a/packager/media/test/CMakeLists.txt
+++ b/packager/media/test/CMakeLists.txt
@@ -6,8 +6,14 @@
 
 add_library(test_data_util STATIC
     test_data_util.cc)
+target_compile_definitions(test_data_util
+    PRIVATE
+    # We used to build off of __FILE__, but that is not always an absolute
+    # path, depending on the version of CMake.  This is consistent.
+    TEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/data")
 target_link_libraries(test_data_util
     glog)
+
 add_library(test_web_server STATIC
     test_web_server.cc)
 target_link_libraries(test_web_server

--- a/packager/media/test/test_data_util.cc
+++ b/packager/media/test/test_data_util.cc
@@ -11,15 +11,16 @@ namespace media {
 
 // Returns a file path for a file in the media/test/data directory.
 std::filesystem::path GetTestDataFilePath(const std::string& name) {
-  std::filesystem::path header_path(__FILE__);
-  return header_path.parent_path() / "data" / name;
+  std::filesystem::path data_dir(TEST_DATA_DIR);
+  return data_dir / name;
 }
 
 // Returns a file path for a file in the media/app/test/testdata directory.
 std::filesystem::path GetAppTestDataFilePath(const std::string& name) {
-  std::filesystem::path header_path(__FILE__);
-  return header_path.parent_path().parent_path() / "app" / "test" / "testdata" /
-         name;
+  std::filesystem::path data_dir(TEST_DATA_DIR);
+  auto app_data_dir =
+      data_dir.parent_path().parent_path() / "app" / "test" / "testdata";
+  return app_data_dir / name;
 }
 
 // Reads a test file from media/test/data directory and returns its content.


### PR DESCRIPTION
The `__FILE__` macro does not always get you an absolute path, so our assumptions about it in test_data_util.cc were flawed.

If `foo.c` references `__FILE__`, something like `gcc -c foo.c`, will define `__FILE__` as `"foo.c"`.  If you use `gcc -c /path/to/foo.c`, then `__FILE__` will be `"/path/to/foo.c"`.

The Ninja generator for CMake only generates absolute paths for source files in certain CMake versions.  (Exact range unknown.)  Rather than require newer CMake versions and depend on CMake's Ninja generator maintaining the latest behavior forever, set the macro TEST_DATA_DIR to point to the test data folder.  This is consistent and never depends on unspecified behavior.

This change will allow the use of the Ninja generator with older versions of CMake, as found in most of our Docker builds.