### PR TITLE
test: Move CentOS 8 tests to CentOS 9 Stream

### DIFF
--- a/packager/testing/dockers/CentOS_Dockerfile
+++ b/packager/testing/dockers/CentOS_Dockerfile
@@ -1,20 +1,10 @@
-FROM centos:8
-
-# Fix up CentOS repo info, which is outdated and not maintained in DockerHub.
-# See https://stackoverflow.com/a/71309215
-RUN cd /etc/yum.repos.d/
-RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+FROM tgagor/centos:stream9
 
 # Install utilities, libraries, and dev tools.
 RUN yum install -y \
         which \
         c-ares-devel libatomic \
-        cmake gcc-toolset-9-gcc gcc-toolset-9-gcc-c++ git python3
-
-# CentOS 8 is old, and the g++ version installed doesn't automatically link the
-# C++ filesystem library as it should.  Activate a newer dev environment.
-ENV PATH="/opt/rh/gcc-toolset-9/root/usr/bin:$PATH"
+        cmake gcc-c++ git python3
 
 # Build and run this docker by mapping shaka-packager with
 # -v "shaka-packager:/shaka-packager".

--- a/packager/third_party/abseil-cpp/CMakeLists.txt
+++ b/packager/third_party/abseil-cpp/CMakeLists.txt
@@ -13,5 +13,10 @@ set(ABSL_PROPAGATE_CXX_STD ON)
 # for one in the system.
 set(ABSL_USE_EXTERNAL_GOOGLETEST ON)
 
+if(NOT MSVC)
+  # Silence a warning about ignored attributes.
+  add_compile_options(-Wno-ignored-attributes)
+endif()
+
 # With these set in scope of this folder, load the library's own CMakeLists.txt.
 add_subdirectory(source)


### PR DESCRIPTION
CentOS 8 is EOL, and the official docker images will not be updated. See https://www.centos.org/centos-linux-eol/

This switches to the latest release (CentOS 9 Stream).  Since CentOS no longer provides official images, this uses a third-party image provider (https://hub.docker.com/u/tgagor)

This change also exposed a warning in absl that needed to be silenced in the default version of GCC in CentOS 9 Stream (GCC 11.4).