### PR TITLE
test: Avoid crashing a test executable

### DIFF
--- a/packager/media/base/container_names_unittest.cc
+++ b/packager/media/base/container_names_unittest.cc
@@ -146,6 +146,7 @@ TEST(ContainerNamesTest, CheckFixedStrings) {
 void TestFile(MediaContainerName expected, const std::string& name) {
   std::filesystem::path path = GetTestDataFilePath(name);
   std::vector<uint8_t> data = ReadTestDataFile(name);
+  ASSERT_FALSE(data.empty());
 
   // Now verify the type.
   EXPECT_EQ(expected, DetermineContainer(data.data(), data.size()))

--- a/packager/media/codecs/av1_parser_unittest.cc
+++ b/packager/media/codecs/av1_parser_unittest.cc
@@ -23,6 +23,7 @@ inline bool operator==(const AV1Parser::Tile& lhs, const AV1Parser::Tile& rhs) {
 
 TEST(AV1ParserTest, ParseIFrameSuccess) {
   const std::vector<uint8_t> buffer = ReadTestDataFile("av1-I-frame-320x240");
+  ASSERT_FALSE(buffer.empty());
 
   AV1Parser parser;
   std::vector<AV1Parser::Tile> tiles;

--- a/packager/media/codecs/h264_parser_unittest.cc
+++ b/packager/media/codecs/h264_parser_unittest.cc
@@ -46,6 +46,7 @@ const uint8_t kPps2[] = {
 
 TEST(H264ParserTest, StreamFileParsing) {
   std::vector<uint8_t> buffer = ReadTestDataFile("test-25fps.h264");
+  ASSERT_FALSE(buffer.empty());
 
   // Number of NALUs in the test stream to be parsed.
   int num_nalus = 759;

--- a/packager/media/formats/mp2t/es_parser_h264_unittest.cc
+++ b/packager/media/formats/mp2t/es_parser_h264_unittest.cc
@@ -153,6 +153,7 @@ class EsParserH264Test : public testing::Test {
 
 void EsParserH264Test::LoadStream(const char* filename) {
   std::vector<uint8_t> buffer = ReadTestDataFile(filename);
+  ASSERT_FALSE(buffer.empty());
 
   // The input file does not have AUDs.
   std::vector<Packet> access_units_without_aud =

--- a/packager/media/formats/mp2t/mp2t_media_parser_unittest.cc
+++ b/packager/media/formats/mp2t/mp2t_media_parser_unittest.cc
@@ -122,6 +122,7 @@ class Mp2tMediaParserTest : public testing::Test {
     InitializeParser();
 
     std::vector<uint8_t> buffer = ReadTestDataFile(filename);
+    ASSERT_FALSE(buffer.empty());
     EXPECT_TRUE(AppendDataInPieces(buffer.data(),
                                    buffer.size(),
                                    append_bytes));

--- a/packager/media/formats/mp4/mp4_media_parser_unittest.cc
+++ b/packager/media/formats/mp4/mp4_media_parser_unittest.cc
@@ -103,9 +103,13 @@ class MP4MediaParserTest : public testing::Test {
 
   bool ParseMP4File(const std::string& filename, int append_bytes) {
     InitializeParser(NULL);
+
     if (!parser_->LoadMoov(GetTestDataFilePath(filename).AsUTF8Unsafe()))
       return false;
+
     std::vector<uint8_t> buffer = ReadTestDataFile(filename);
+    ASSERT_FALSE(buffer.empty());
+
     return AppendDataInPieces(buffer.data(), buffer.size(), append_bytes);
   }
 };
@@ -206,6 +210,8 @@ TEST_F(MP4MediaParserTest, Flush) {
   InitializeParser(NULL);
 
   std::vector<uint8_t> buffer = ReadTestDataFile("bear-640x360-av_frag.mp4");
+  ASSERT_FALSE(buffer.empty());
+
   EXPECT_TRUE(AppendDataInPieces(buffer.data(), 65536, 512));
   EXPECT_TRUE(parser_->Flush());
   EXPECT_EQ(2u, num_streams_);
@@ -226,6 +232,8 @@ TEST_F(MP4MediaParserTest, NoMoovAfterFlush) {
   InitializeParser(NULL);
 
   std::vector<uint8_t> buffer = ReadTestDataFile("bear-640x360-av_frag.mp4");
+  ASSERT_FALSE(buffer.empty());
+
   EXPECT_TRUE(AppendDataInPieces(buffer.data(), buffer.size(), 512));
   EXPECT_TRUE(parser_->Flush());
 
@@ -255,6 +263,8 @@ TEST_F(MP4MediaParserTest, CencInitWithoutDecryptionSource) {
 
   std::vector<uint8_t> buffer =
       ReadTestDataFile("bear-640x360-v_frag-cenc-aux.mp4");
+  ASSERT_FALSE(buffer.empty());
+
   const int kFirstMoofOffset = 1646;
   EXPECT_TRUE(AppendDataInPieces(buffer.data(), kFirstMoofOffset, 512));
   EXPECT_EQ(1u, num_streams_);
@@ -274,6 +284,8 @@ TEST_F(MP4MediaParserTest, CencWithDecryptionSourceAndAuxInMdat) {
 
   std::vector<uint8_t> buffer =
       ReadTestDataFile("bear-640x360-v_frag-cenc-aux.mp4");
+  ASSERT_FALSE(buffer.empty());
+
   EXPECT_TRUE(AppendDataInPieces(buffer.data(), buffer.size(), 512));
   EXPECT_EQ(1u, num_streams_);
   EXPECT_EQ(82u, num_samples_);
@@ -293,6 +305,8 @@ TEST_F(MP4MediaParserTest, CencWithDecryptionSourceAndSenc) {
 
   std::vector<uint8_t> buffer =
       ReadTestDataFile("bear-640x360-v_frag-cenc-senc.mp4");
+  ASSERT_FALSE(buffer.empty());
+
   EXPECT_TRUE(AppendDataInPieces(buffer.data(), buffer.size(), 512));
   EXPECT_EQ(1u, num_streams_);
   EXPECT_EQ(82u, num_samples_);

--- a/packager/media/formats/wvm/wvm_media_parser_unittest.cc
+++ b/packager/media/formats/wvm/wvm_media_parser_unittest.cc
@@ -154,6 +154,8 @@ class WvmMediaParserTest : public testing::Test {
     InitializeParser();
 
     std::vector<uint8_t> buffer = ReadTestDataFile(filename);
+    ASSERT_FALSE(buffer.empty());
+
     EXPECT_TRUE(parser_->Parse(buffer.data(), static_cast<int>(buffer.size())));
   }
 };
@@ -161,7 +163,10 @@ class WvmMediaParserTest : public testing::Test {
 TEST_F(WvmMediaParserTest, ParseWvmWithoutKeySource) {
   key_source_.reset();
   InitializeParser();
+
   std::vector<uint8_t> buffer = ReadTestDataFile(kWvmFile);
+  ASSERT_FALSE(buffer.empty());
+
   EXPECT_TRUE(parser_->Parse(buffer.data(), static_cast<int>(buffer.size())));
   EXPECT_EQ(kExpectedStreams, stream_map_.size());
   EXPECT_EQ(kExpectedVideoFrameCount, video_frame_count_);
@@ -184,7 +189,10 @@ TEST_F(WvmMediaParserTest, ParseWvmWithoutKeySource) {
 TEST_F(WvmMediaParserTest, ParseWvmInitWithoutKeySource) {
   key_source_.reset();
   InitializeParser();
+
   std::vector<uint8_t> buffer = ReadTestDataFile(kWvmFile);
+  ASSERT_FALSE(buffer.empty());
+
   EXPECT_TRUE(parser_->Parse(buffer.data(), kInitDataSize));
   EXPECT_EQ(kExpectedStreams, stream_map_.size());
 }

--- a/packager/media/test/test_data_util.cc
+++ b/packager/media/test/test_data_util.cc
@@ -29,7 +29,7 @@ std::vector<uint8_t> ReadTestDataFile(const std::string& name) {
 
   FILE* f = fopen(path.string().c_str(), "rb");
   if (!f) {
-    LOG(FATAL) << "Failed to read test data from " << path;
+    LOG(ERROR) << "Failed to read test data from " << path;
     return std::vector<uint8_t>();
   }
 


### PR DESCRIPTION
LOG(FATAL) aborts the executable, which means gtest can't write any reports it might be configured to write when tests are complete.  This will interfere with reporting.

This converts the only use of LOG(FATAL), which was in ReadTestDataFile(), to LOG(ERROR).  This also updates test cases to avoid crashing when ReadTestDataFile() returns an empty buffer.