### PR TITLE
ci: Fix workflow warnings

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -39,7 +39,7 @@ jobs:
               breathe
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,7 +50,7 @@ jobs:
       INCLUDE: ${{ steps.configure.outputs.INCLUDE }}
       OS: ${{ steps.configure.outputs.OS }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
 
@@ -67,8 +67,13 @@ jobs:
           const os = include.map((config) => config.os);
 
           // Output JSON objects consumed by the build matrix below.
-          console.log(`::set-output name=INCLUDE::${ JSON.stringify(include) }`);
-          console.log(`::set-output name=OS::${ JSON.stringify(os) }`);
+          const fs = require('fs');
+          fs.writeFileSync(process.env.GITHUB_OUTPUT,
+              [
+                `INCLUDE=${ JSON.stringify(include) }`,
+                `OS=${ JSON.stringify(os) }`,
+              ].join('\n'),
+              {flag: 'a'});
 
           // Log the outputs, for the sake of debugging this script.
           console.log({enableSelfHosted, include, os});
@@ -93,7 +98,7 @@ jobs:
         run: git config --global core.autocrlf false
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
           submodules: recursive

--- a/.github/workflows/docker-hub-release.yaml
+++ b/.github/workflows/docker-hub-release.yaml
@@ -34,7 +34,7 @@ jobs:
           echo "TARGET_REF=${{ github.event.inputs.ref || github.event.release.tag_name }}" >> $GITHUB_ENV
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ env.TARGET_REF }}
           submodules: recursive

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
           submodules: recursive

--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -61,7 +61,7 @@ jobs:
       release_id: ${{ steps.draft_release.outputs.id }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ needs.setup.outputs.tag }}
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
           # We must use 'fetch-depth: 2', or else the linter won't have another

--- a/.github/workflows/npm-release.yaml
+++ b/.github/workflows/npm-release.yaml
@@ -35,7 +35,7 @@ jobs:
           echo "TARGET_REF=${{ github.event.inputs.ref || github.event.release.tag_name }}" >> $GITHUB_ENV
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ env.TARGET_REF }}
 

--- a/.github/workflows/test-linux-distros.yaml
+++ b/.github/workflows/test-linux-distros.yaml
@@ -29,7 +29,7 @@ jobs:
     outputs:
       MATRIX: ${{ steps.configure.outputs.MATRIX }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
 
@@ -44,7 +44,9 @@ jobs:
           });
 
           // Output a JSON object consumed by the build matrix below.
-          console.log(`::set-output name=MATRIX::${ JSON.stringify(matrix) }`);
+          fs.writeFileSync(process.env.GITHUB_OUTPUT,
+              `MATRIX=${ JSON.stringify(matrix) }`,
+              {flag: 'a'});
 
           // Log the outputs, for the sake of debugging this script.
           console.log({matrix});
@@ -63,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
           submodules: recursive

--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -36,7 +36,7 @@ jobs:
           echo "::set-output name=ref::${{ github.event.inputs.ref || github.event.release.tag_name }}"
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ steps.ref.outputs.ref }}
 


### PR DESCRIPTION
Fixes the following warnings from GitHub Actions:
 - "The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/"
 - "The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/"