### PR TITLE
ci: Collect and report test results

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -152,6 +152,12 @@ jobs:
       - name: Test
         run: ctest -C "${{ matrix.build_type }}" -V --test-dir build/
 
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@150e2f992e4fad1379da2056d1d1c279f520e058
+        if: ${{ always() }}
+        with:
+          report_paths: 'junit-reports/TEST-*.xml'
+
       # TODO(joeyparrish): Prepare artifacts when build system is complete again
 #      - name: Prepare artifacts (static release only)
 #        run: |

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@
 .repo
 .settings
 build/
-/packager/docs/
+junit-reports/
+packager/docs/
 .vscode/

--- a/packager/CMakeLists.txt
+++ b/packager/CMakeLists.txt
@@ -43,6 +43,9 @@ else()
   add_compile_options(-Wno-unknown-warning-option)
 endif()
 
+# Include our module for gtest-based testing.
+include("gtest.cmake")
+
 # Include our module for building protos.
 include("protobuf.cmake")
 

--- a/packager/file/CMakeLists.txt
+++ b/packager/file/CMakeLists.txt
@@ -50,4 +50,4 @@ target_link_libraries(file_unittest
     gtest_main
     nlohmann_json
     test_web_server)
-add_test(NAME file_unittest COMMAND file_unittest)
+add_gtest(file_unittest)

--- a/packager/gtest.cmake
+++ b/packager/gtest.cmake
@@ -1,0 +1,40 @@
+# Copyright 2023 Google LLC. All rights reserved.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file or at
+# https://developers.google.com/open-source/licenses/bsd
+
+# Define a custom function to create gtest-based tests.  This will standardize
+# all gtests to output junit XML files that can be used to flag specific test
+# failures on a PR.
+
+function(add_gtest NAME)
+  cmake_parse_arguments(PARSE_ARGV
+      # How many arguments to skip (1 for the library name)
+      1
+      # Prefix for automatic variables created by the parser
+      ADD_GTEST
+      # Boolean flags
+      ""
+      # One-value arguments
+      "WORKING_DIRECTORY"
+      # Multi-value arguments
+      "")
+
+  # Optional working directory for the test executable.
+  if(${ADD_GTEST_WORKING_DIRECTORY})
+    set(ADD_GTEST_WORKING_DIRECTORY_SETTING
+        WORKING_DIRECTORY ${ADD_GTEST_WORKING_DIRECTORY})
+  else()
+    set(ADD_GTEST_WORKING_DIRECTORY_SETTING)
+  endif()
+
+  # Where we output test results in junit format.
+  set(ADD_GTEST_REPORT_PATH
+      ${PROJECT_SOURCE_DIR}/junit-reports/TEST-${NAME}.xml)
+
+  # Output gtest results in junit format in a consistent place.
+  add_test(NAME ${NAME}
+           COMMAND ${NAME} --gtest_output=xml:${ADD_GTEST_REPORT_PATH}
+           ${ADD_GTEST_WORKING_DIRECTORY_SETTINGS})
+endfunction()

--- a/packager/kv_pairs/CMakeLists.txt
+++ b/packager/kv_pairs/CMakeLists.txt
@@ -17,4 +17,4 @@ target_link_libraries(kv_pairs_unittest
     gmock
     gtest
     gtest_main)
-add_test(NAME kv_pairs_unittest COMMAND kv_pairs_unittest)
+add_gtest(kv_pairs_unittest)

--- a/packager/media/base/CMakeLists.txt
+++ b/packager/media/base/CMakeLists.txt
@@ -105,4 +105,4 @@ target_link_libraries(media_base_unittest
     gtest_main
     test_data_util
     test_web_server)
-add_test(NAME media_base_unittest COMMAND media_base_unittest)
+add_gtest(media_base_unittest)

--- a/packager/media/chunking/CMakeLists.txt
+++ b/packager/media/chunking/CMakeLists.txt
@@ -10,7 +10,6 @@ add_library(chunking STATIC
     sync_point_queue.cc
     text_chunker.cc
 )
-
 target_link_libraries(chunking
     media_base
 )
@@ -20,7 +19,6 @@ add_executable(chunking_unittest
     cue_alignment_handler_unittest.cc
     text_chunker_unittest.cc
 )
-
 target_link_libraries(chunking_unittest
     gmock
     gtest
@@ -28,5 +26,4 @@ target_link_libraries(chunking_unittest
     media_handler_test_base
     chunking
 )
-
-add_test(NAME chunking_unittest COMMAND chunking_unittest)
+add_gtest(chunking_unittest)

--- a/packager/media/codecs/CMakeLists.txt
+++ b/packager/media/codecs/CMakeLists.txt
@@ -66,4 +66,4 @@ target_link_libraries(codecs_unittest
     gtest_main
     test_data_util)
 
-add_test(NAME codecs_unittest COMMAND codecs_unittest)
+add_gtest(codecs_unittest)

--- a/packager/media/crypto/CMakeLists.txt
+++ b/packager/media/crypto/CMakeLists.txt
@@ -28,5 +28,4 @@ target_link_libraries(media_crypto_unittest
         gmock
         gtest
         gtest_main)
-
-add_test(NAME media_crypto_unittest COMMAND media_crypto_unittest)
+add_gtest(media_crypto_unittest)

--- a/packager/media/event/CMakeLists.txt
+++ b/packager/media/event/CMakeLists.txt
@@ -13,7 +13,6 @@ add_library(media_event STATIC
     muxer_listener_internal.cc
     vod_media_info_dump_muxer_listener.cc
 )
-
 target_link_libraries(media_event
     file
     mpd_media_info_proto
@@ -24,7 +23,6 @@ target_link_libraries(media_event
 add_library(mock_muxer_listener STATIC
     mock_muxer_listener.cc
 )
-
 target_link_libraries(mock_muxer_listener
     gmock
     media_event
@@ -39,7 +37,6 @@ add_executable(media_event_unittest
     muxer_listener_test_helper.cc
     vod_media_info_dump_muxer_listener_unittest.cc
 )
-
 target_link_libraries(media_event_unittest
     file
     file_test_util
@@ -50,5 +47,4 @@ target_link_libraries(media_event_unittest
     media_event
     mock_muxer_listener
 )
-
-add_test(NAME media_event_unittest COMMAND media_event_unittest)
+add_gtest(media_event_unittest)

--- a/packager/media/formats/webm/CMakeLists.txt
+++ b/packager/media/formats/webm/CMakeLists.txt
@@ -26,7 +26,6 @@ add_library(formats_webm STATIC
     webm_video_client.cc
     webm_webvtt_parser.cc
 )
-
 target_link_libraries(formats_webm
     webm
     file
@@ -48,7 +47,6 @@ add_executable(webm_unittest
     webm_tracks_parser_unittest.cc
     webm_webvtt_parser_unittest.cc
 )
-
 target_link_libraries(webm_unittest
     formats_webm
     gmock
@@ -56,5 +54,4 @@ target_link_libraries(webm_unittest
     gtest_main
     test_data_util
 )
-
-add_test(NAME webm_unittest COMMAND webm_unittest)
+add_gtest(webm_unittest)

--- a/packager/media/trick_play/CMakeLists.txt
+++ b/packager/media/trick_play/CMakeLists.txt
@@ -21,5 +21,4 @@ target_link_libraries(media_trick_play_unittest
     gmock
     gtest
     gtest_main)
-
-add_test(NAME media_trick_play_unittest COMMAND media_trick_play_unittest)
+add_gtest(media_trick_play_unittest)

--- a/packager/status/CMakeLists.txt
+++ b/packager/status/CMakeLists.txt
@@ -22,4 +22,4 @@ target_link_libraries(status_unittest
     gmock
     gtest
     gtest_main)
-add_test(NAME status_unittest COMMAND status_unittest)
+add_gtest(status_unittest)


### PR DESCRIPTION
All gtest-based tests should now use add_gtest.  Results from these tests will be surfaced more prominently in GitHub Actions.  Before this, it was hard to find test failures in the log.