### PR TITLE
test: Use a random HTTP port for web server tests

### DIFF
--- a/packager/media/base/http_key_fetcher_unittest.cc
+++ b/packager/media/base/http_key_fetcher_unittest.cc
@@ -12,18 +12,6 @@
 #include "packager/media/test/test_web_server.h"
 #include "packager/status/status_test_util.h"
 
-namespace {
-// A completely arbitrary port number, unlikely to be in use.
-const int kTestServerPort = 58405;
-
-// Reflects back the method, body, and headers of the request as JSON.
-const char kTestUrl[] = "http://localhost:58405/reflect";
-// Returns the requested HTTP status code.
-const char kTestUrl404[] = "http://localhost:58405/status?code=404";
-// Returns after the requested delay.
-const char kTestUrlDelayTwoSecs[] = "http://localhost:58405/delay?seconds=2";
-}  // namespace
-
 namespace shaka {
 namespace media {
 
@@ -35,37 +23,37 @@ namespace media {
 // enough.
 class HttpKeyFetcherTest : public testing::Test {
  protected:
-  void SetUp() override { ASSERT_TRUE(server_.Start(kTestServerPort)); }
+  void SetUp() override { ASSERT_TRUE(server_.Start()); }
 
- private:
   TestWebServer server_;
 };
 
 TEST_F(HttpKeyFetcherTest, HttpGet) {
   HttpKeyFetcher fetcher;
   std::string response;
-  ASSERT_OK(fetcher.Get(kTestUrl, &response));
+  ASSERT_OK(fetcher.Get(server_.ReflectUrl(), &response));
   EXPECT_NE(std::string::npos, response.find("\"method\":\"GET\""));
 }
 
 TEST_F(HttpKeyFetcherTest, HttpPost) {
   HttpKeyFetcher fetcher;
   std::string response;
-  ASSERT_OK(fetcher.Post(kTestUrl, "", &response));
+  ASSERT_OK(fetcher.Post(server_.ReflectUrl(), "", &response));
   EXPECT_NE(std::string::npos, response.find("\"method\":\"POST\""));
 }
 
 TEST_F(HttpKeyFetcherTest, HttpFetchKeys) {
   HttpKeyFetcher fetcher;
   std::string response;
-  ASSERT_OK(fetcher.FetchKeys(kTestUrl, "foo=62&type=mp4", &response));
+  ASSERT_OK(
+      fetcher.FetchKeys(server_.ReflectUrl(), "foo=62&type=mp4", &response));
   EXPECT_NE(std::string::npos, response.find("\"foo=62&type=mp4\""));
 }
 
 TEST_F(HttpKeyFetcherTest, InvalidUrl) {
   HttpKeyFetcher fetcher;
   std::string response;
-  Status status = fetcher.FetchKeys(kTestUrl404, "", &response);
+  Status status = fetcher.FetchKeys(server_.StatusCodeUrl(404), "", &response);
   EXPECT_EQ(error::HTTP_FAILURE, status.error_code());
   EXPECT_NE(std::string::npos, status.error_message().find("404"));
 }
@@ -74,7 +62,7 @@ TEST_F(HttpKeyFetcherTest, SmallTimeout) {
   const int32_t kTimeoutInSeconds = 1;
   HttpKeyFetcher fetcher(kTimeoutInSeconds);
   std::string response;
-  Status status = fetcher.FetchKeys(kTestUrlDelayTwoSecs, "", &response);
+  Status status = fetcher.FetchKeys(server_.DelayUrl(2), "", &response);
   EXPECT_EQ(error::TIME_OUT, status.error_code());
 }
 
@@ -82,7 +70,7 @@ TEST_F(HttpKeyFetcherTest, BigTimeout) {
   const int32_t kTimeoutInSeconds = 5;
   HttpKeyFetcher fetcher(kTimeoutInSeconds);
   std::string response;
-  Status status = fetcher.FetchKeys(kTestUrlDelayTwoSecs, "", &response);
+  Status status = fetcher.FetchKeys(server_.DelayUrl(2), "", &response);
   EXPECT_OK(status);
 }
 

--- a/packager/media/test/test_web_server.h
+++ b/packager/media/test/test_web_server.h
@@ -17,6 +17,7 @@
 // Forward declare mongoose struct types, used as pointers below.
 struct mg_connection;
 struct mg_http_message;
+struct mg_mgr;
 
 namespace shaka {
 namespace media {
@@ -26,7 +27,20 @@ class TestWebServer {
   TestWebServer();
   ~TestWebServer();
 
-  bool Start(int port);
+  bool Start();
+
+  // Reflects back the request characteristics as a JSON response.
+  std::string ReflectUrl() { return base_url_ + "/reflect"; }
+
+  // Responds with a specific HTTP status code.
+  std::string StatusCodeUrl(int code) {
+    return base_url_ + "/status?code=" + std::to_string(code);
+  }
+
+  // Responds with HTTP 200 after a delay.
+  std::string DelayUrl(int seconds) {
+    return base_url_ + "/delay?seconds=" + std::to_string(seconds);
+  }
 
  private:
   enum TestWebServerStatus {
@@ -49,7 +63,12 @@ class TestWebServer {
 
   std::unique_ptr<std::thread> thread_;
 
-  void ThreadCallback(int port);
+  std::string base_url_;
+
+  // Sets base_url_.
+  bool TryListenOnPort(struct mg_mgr* manager, int port);
+
+  void ThreadCallback();
 
   static void HandleEvent(struct mg_connection* connection,
                           int event,


### PR DESCRIPTION
This will pick a random HTTP port for the test web server, and retry up to 10 times if the chosen port number is in use.