### PR TITLE
fix: apply cmake fixes after merge of #1210

### DIFF
--- a/packager/mpd/base/adaptation_set.cc
+++ b/packager/mpd/base/adaptation_set.cc
@@ -296,7 +296,7 @@ std::optional<xml::XmlNode> AdaptationSet::GetXml() {
       !adaptation_set.AddSupplementalProperty(
           "urn:mpeg:mpegB:cicp:TransferCharacteristics",
           std::to_string(transfer_characteristics_))) {
-    return base::nullopt;
+    return std::nullopt;
   }
 
   // Note: must be checked before checking segments_aligned_ (below). So that

--- a/packager/mpd/base/adaptation_set.h
+++ b/packager/mpd/base/adaptation_set.h
@@ -181,7 +181,7 @@ class AdaptationSet {
   void set_codec(const std::string& codec) { codec_ = codec; };
 
   /// @return transfer_characteristics.
-  const uint32_t transfer_characteristics() const {
+  uint32_t transfer_characteristics() const {
     return transfer_characteristics_;
   }
 

--- a/packager/mpd/base/mpd_utils.h
+++ b/packager/mpd/base/mpd_utils.h
@@ -11,6 +11,7 @@
 
 #include <libxml/tree.h>
 
+#include <cstdint>
 #include <list>
 #include <string>
 


### PR DESCRIPTION
build in CMake branch is broken at least locally on OS X after #1210 was merged which introduced some new warnings and reintroduced base::nullopt.