### PR TITLE
style: Sort headers to comply with the style guide

### DIFF
--- a/packager/app/crypto_flags.cc
+++ b/packager/app/crypto_flags.cc
@@ -4,10 +4,11 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <absl/flags/flag.h>
 #include <packager/app/crypto_flags.h>
 
 #include <cstdio>
+
+#include <absl/flags/flag.h>
 
 ABSL_FLAG(std::string,
           protection_scheme,

--- a/packager/app/job_manager.h
+++ b/packager/app/job_manager.h
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include <absl/synchronization/mutex.h>
+
 #include <packager/status/status.h>
 
 namespace shaka {

--- a/packager/app/mpd_generator.cc
+++ b/packager/app/mpd_generator.cc
@@ -6,22 +6,23 @@
 
 #include <iostream>
 
+#if defined(OS_WIN)
+#include <codecvt>
+#include <functional>
+#endif  // defined(OS_WIN)
+
 #include <absl/flags/parse.h>
 #include <absl/flags/usage.h>
 #include <absl/flags/usage_config.h>
 #include <absl/strings/str_format.h>
 #include <absl/strings/str_split.h>
 #include <glog/logging.h>
+
 #include <packager/app/mpd_generator_flags.h>
 #include <packager/app/vlog_flags.h>
 #include <packager/mpd/util/mpd_writer.h>
 #include <packager/tools/license_notice.h>
 #include <packager/version/version.h>
-
-#if defined(OS_WIN)
-#include <codecvt>
-#include <functional>
-#endif  // defined(OS_WIN)
 
 ABSL_FLAG(bool, licenses, false, "Dump licenses.");
 ABSL_FLAG(std::string,

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -4,9 +4,15 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <absl/flags/flag.h>
 #include <iostream>
+#include <optional>
 
+#if defined(OS_WIN)
+#include <codecvt>
+#include <functional>
+#endif  // defined(OS_WIN)
+
+#include <absl/flags/flag.h>
 #include <absl/flags/parse.h>
 #include <absl/flags/usage.h>
 #include <absl/flags/usage_config.h>
@@ -14,6 +20,7 @@
 #include <absl/strings/str_format.h>
 #include <absl/strings/str_split.h>
 #include <glog/logging.h>
+
 #include <packager/app/ad_cue_generator_flags.h>
 #include <packager/app/crypto_flags.h>
 #include <packager/app/hls_flags.h>
@@ -31,12 +38,6 @@
 #include <packager/kv_pairs/kv_pairs.h>
 #include <packager/tools/license_notice.h>
 #include <packager/utils/string_trim_split.h>
-#include <optional>
-
-#if defined(OS_WIN)
-#include <codecvt>
-#include <functional>
-#endif  // defined(OS_WIN)
 
 ABSL_FLAG(bool, dump_stream_info, false, "Dump demuxed stream info.");
 ABSL_FLAG(bool, licenses, false, "Dump licenses.");

--- a/packager/app/packager_util.cc
+++ b/packager/app/packager_util.cc
@@ -7,6 +7,7 @@
 #include <packager/app/packager_util.h>
 
 #include <glog/logging.h>
+
 #include <packager/file/file.h>
 #include <packager/media/base/media_handler.h>
 #include <packager/media/base/muxer_options.h>

--- a/packager/app/raw_key_encryption_flags.cc
+++ b/packager/app/raw_key_encryption_flags.cc
@@ -6,9 +6,8 @@
 //
 // Defines command line flags for raw key encryption/decryption.
 
-#include <packager/utils/absl_flag_hexbytes.h>
-
 #include <packager/app/validate_flag.h>
+#include <packager/utils/absl_flag_hexbytes.h>
 
 ABSL_FLAG(bool,
           enable_fixed_key_encryption,

--- a/packager/app/stream_descriptor.cc
+++ b/packager/app/stream_descriptor.cc
@@ -5,12 +5,13 @@
 // https://developers.google.com/open-source/licenses/bsd
 
 #include <packager/app/stream_descriptor.h>
-#include <packager/kv_pairs/kv_pairs.h>
-#include <packager/utils/string_trim_split.h>
 
 #include <absl/strings/numbers.h>
 #include <absl/strings/str_split.h>
 #include <glog/logging.h>
+
+#include <packager/kv_pairs/kv_pairs.h>
+#include <packager/utils/string_trim_split.h>
 
 namespace shaka {
 

--- a/packager/app/stream_descriptor.h
+++ b/packager/app/stream_descriptor.h
@@ -7,6 +7,7 @@
 #ifndef APP_STREAM_DESCRIPTOR_H_
 #define APP_STREAM_DESCRIPTOR_H_
 
+#include <optional>
 #include <string>
 
 #include <packager/packager.h>

--- a/packager/app/validate_flag.h
+++ b/packager/app/validate_flag.h
@@ -6,8 +6,8 @@
 //
 // Flag validation help functions.
 
-#ifndef APP_VALIDATE_FLAG_H_
-#define APP_VALIDATE_FLAG_H_
+#ifndef PACKAGER_APP_VALIDATE_FLAG_H_
+#define PACKAGER_APP_VALIDATE_FLAG_H_
 
 #include <string>
 
@@ -54,4 +54,4 @@ bool ValidateFlag(const char* flag_name,
 
 }  // namespace shaka
 
-#endif  // APP_VALIDATE_FLAG_H_
+#endif  // PACKAGER_APP_VALIDATE_FLAG_H_

--- a/packager/app/vlog_flags.cc
+++ b/packager/app/vlog_flags.cc
@@ -6,8 +6,10 @@
 //
 // Defines verbose logging flags.
 
-#include <absl/strings/numbers.h>
 #include <packager/app/vlog_flags.h>
+
+#include <absl/strings/numbers.h>
+
 #include <packager/kv_pairs/kv_pairs.h>
 
 ABSL_FLAG(int32_t,

--- a/packager/app/widevine_encryption_flags.cc
+++ b/packager/app/widevine_encryption_flags.cc
@@ -8,12 +8,14 @@
 
 #include <packager/app/widevine_encryption_flags.h>
 
+#include <string_view>
+
 #include <absl/flags/flag.h>
 #include <absl/strings/ascii.h>
 #include <absl/strings/match.h>
 #include <glog/logging.h>
+
 #include <packager/app/validate_flag.h>
-#include <string_view>
 
 ABSL_FLAG(bool,
           enable_widevine_encryption,

--- a/packager/file/callback_file.cc
+++ b/packager/file/callback_file.cc
@@ -7,6 +7,7 @@
 #include <packager/file/callback_file.h>
 
 #include <glog/logging.h>
+
 #include <packager/macros.h>
 
 namespace shaka {

--- a/packager/file/callback_file_unittest.cc
+++ b/packager/file/callback_file_unittest.cc
@@ -6,10 +6,10 @@
 
 #include <packager/file/callback_file.h>
 
+#include <memory>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-
-#include <memory>
 
 #include <packager/file/file.h>
 #include <packager/file/file_closer.h>

--- a/packager/file/file.cc
+++ b/packager/file/file.cc
@@ -6,9 +6,8 @@
 
 #include <packager/file/file.h>
 
-#include <inttypes.h>
-
 #include <algorithm>
+#include <cinttypes>
 #include <filesystem>
 #include <memory>
 

--- a/packager/file/file.h
+++ b/packager/file/file.h
@@ -7,8 +7,7 @@
 #ifndef PACKAGER_FILE_FILE_H_
 #define PACKAGER_FILE_FILE_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <string>
 
 #include <packager/file/public/buffer_callback_params.h>

--- a/packager/file/file_closer.h
+++ b/packager/file/file_closer.h
@@ -8,6 +8,7 @@
 #define MEDIA_FILE_FILE_CLOSER_H_
 
 #include <glog/logging.h>
+
 #include <packager/file/file.h>
 
 namespace shaka {

--- a/packager/file/file_test_util.h
+++ b/packager/file/file_test_util.h
@@ -7,11 +7,11 @@
 #ifndef MEDIA_FILE_FILE_TEST_UTIL_H_
 #define MEDIA_FILE_FILE_TEST_UTIL_H_
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
-
 #include <iterator>
 #include <string>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 #include <packager/file/file.h>
 

--- a/packager/file/file_unittest.cc
+++ b/packager/file/file_unittest.cc
@@ -4,14 +4,15 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <gtest/gtest.h>
-#include <cstdio>
+#include <packager/file/file.h>
 
+#include <cstdio>
 #include <filesystem>
 #include <locale>
 
 #include <absl/flags/declare.h>
-#include <packager/file/file.h>
+#include <gtest/gtest.h>
+
 #include <packager/file/file_test_util.h>
 #include <packager/flag_saver.h>
 

--- a/packager/file/file_util_unittest.cc
+++ b/packager/file/file_util_unittest.cc
@@ -6,9 +6,8 @@
 
 #include <packager/file/file_util.h>
 
-#include <gtest/gtest.h>
-
 #include <glog/logging.h>
+#include <gtest/gtest.h>
 
 namespace shaka {
 

--- a/packager/file/http_file.cc
+++ b/packager/file/http_file.cc
@@ -6,12 +6,11 @@
 
 #include <packager/file/http_file.h>
 
-#include <curl/curl.h>
-
 #include <absl/flags/declare.h>
 #include <absl/flags/flag.h>
 #include <absl/strings/escaping.h>
 #include <absl/strings/str_format.h>
+#include <curl/curl.h>
 #include <glog/logging.h>
 
 #include <packager/file/thread_pool.h>

--- a/packager/file/http_file_unittest.cc
+++ b/packager/file/http_file_unittest.cc
@@ -6,16 +6,16 @@
 
 #include <packager/file/http_file.h>
 
-#include <gtest/gtest.h>
-
 #include <memory>
 #include <vector>
 
 #include <absl/strings/str_split.h>
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
 #include <packager/file/file.h>
 #include <packager/file/file_closer.h>
 #include <packager/media/test/test_web_server.h>
-#include <nlohmann/json.hpp>
 
 #define ASSERT_JSON_STRING(json, key, value) \
   ASSERT_EQ(GetJsonString((json), (key)), (value)) << "JSON is " << (json)

--- a/packager/file/io_cache.cc
+++ b/packager/file/io_cache.cc
@@ -6,9 +6,8 @@
 
 #include <packager/file/io_cache.h>
 
-#include <string.h>
-
 #include <algorithm>
+#include <cstring>
 
 #include <glog/logging.h>
 

--- a/packager/file/io_cache.h
+++ b/packager/file/io_cache.h
@@ -7,11 +7,11 @@
 #ifndef PACKAGER_FILE_IO_CACHE_H_
 #define PACKAGER_FILE_IO_CACHE_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <vector>
 
 #include <absl/synchronization/mutex.h>
+
 #include <packager/macros.h>
 
 namespace shaka {

--- a/packager/file/io_cache_unittest.cc
+++ b/packager/file/io_cache_unittest.cc
@@ -6,12 +6,12 @@
 
 #include <packager/file/io_cache.h>
 
-#include <gtest/gtest.h>
-#include <string.h>
-
 #include <algorithm>
 #include <chrono>
+#include <cstring>
 #include <thread>
+
+#include <gtest/gtest.h>
 
 namespace {
 const uint64_t kBlockSize = 256;

--- a/packager/file/local_file.cc
+++ b/packager/file/local_file.cc
@@ -6,14 +6,13 @@
 
 #include <packager/file/local_file.h>
 
-#include <cstdio>
-
 #if defined(OS_WIN)
 #include <windows.h>
 #else
 #include <sys/stat.h>
 #endif  // defined(OS_WIN)
 
+#include <cstdio>
 #include <filesystem>
 
 #include <glog/logging.h>

--- a/packager/file/local_file.h
+++ b/packager/file/local_file.h
@@ -7,8 +7,7 @@
 #ifndef PACKAGER_FILE_LOCAL_FILE_H_
 #define PACKAGER_FILE_LOCAL_FILE_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <string>
 
 #include <packager/file/file.h>

--- a/packager/file/memory_file.cc
+++ b/packager/file/memory_file.cc
@@ -6,9 +6,8 @@
 
 #include <packager/file/memory_file.h>
 
-#include <string.h>  // for memcpy
-
 #include <algorithm>
+#include <cstring>  // for memcpy
 #include <map>
 #include <memory>
 #include <set>

--- a/packager/file/memory_file.h
+++ b/packager/file/memory_file.h
@@ -7,8 +7,7 @@
 #ifndef MEDIA_FILE_MEDIA_FILE_H_
 #define MEDIA_FILE_MEDIA_FILE_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/packager/file/memory_file_unittest.cc
+++ b/packager/file/memory_file_unittest.cc
@@ -4,8 +4,9 @@
 
 #include <packager/file/memory_file.h>
 
-#include <gtest/gtest.h>
 #include <memory>
+
+#include <gtest/gtest.h>
 
 #include <packager/file/file.h>
 #include <packager/file/file_closer.h>

--- a/packager/file/thread_pool.h
+++ b/packager/file/thread_pool.h
@@ -12,6 +12,7 @@
 
 #include <absl/base/thread_annotations.h>
 #include <absl/synchronization/mutex.h>
+
 #include <packager/macros.h>
 
 namespace shaka {

--- a/packager/file/threaded_io_file.h
+++ b/packager/file/threaded_io_file.h
@@ -11,6 +11,7 @@
 #include <memory>
 
 #include <absl/synchronization/mutex.h>
+
 #include <packager/file/file.h>
 #include <packager/file/file_closer.h>
 #include <packager/file/io_cache.h>

--- a/packager/file/udp_file.cc
+++ b/packager/file/udp_file.cc
@@ -29,6 +29,7 @@
 #include <limits>
 
 #include <glog/logging.h>
+
 #include <packager/file/udp_options.h>
 
 namespace shaka {

--- a/packager/file/udp_file.h
+++ b/packager/file/udp_file.h
@@ -7,11 +7,8 @@
 #ifndef MEDIA_FILE_UDP_FILE_H_
 #define MEDIA_FILE_UDP_FILE_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <string>
-
-#include <packager/file/file.h>
 
 #if defined(OS_WIN)
 #include <windows.h>
@@ -19,6 +16,8 @@
 #else
 typedef int SOCKET;
 #endif  // defined(OS_WIN)
+
+#include <packager/file/file.h>
 
 namespace shaka {
 

--- a/packager/file/udp_options.cc
+++ b/packager/file/udp_options.cc
@@ -12,6 +12,7 @@
 #include <absl/strings/numbers.h>
 #include <absl/strings/str_split.h>
 #include <glog/logging.h>
+
 #include <packager/kv_pairs/kv_pairs.h>
 #include <packager/macros.h>
 

--- a/packager/file/udp_options_unittest.cc
+++ b/packager/file/udp_options_unittest.cc
@@ -6,10 +6,10 @@
 
 #include <packager/file/udp_options.h>
 
-#include <gtest/gtest.h>
-
 #include <absl/flags/declare.h>
 #include <absl/flags/flag.h>
+#include <gtest/gtest.h>
+
 #include <packager/flag_saver.h>
 
 ABSL_DECLARE_FLAG(std::string, udp_interface_address);

--- a/packager/hls/base/master_playlist.cc
+++ b/packager/hls/base/master_playlist.cc
@@ -7,18 +7,18 @@
 #include <packager/hls/base/master_playlist.h>
 
 #include <algorithm>  // std::max
-
-#include <inttypes.h>
+#include <cstdint>
+#include <filesystem>
 
 #include <absl/strings/numbers.h>
 #include <absl/strings/str_format.h>
 #include <absl/strings/str_join.h>
 #include <glog/logging.h>
+
 #include <packager/file/file.h>
 #include <packager/hls/base/media_playlist.h>
 #include <packager/hls/base/tag.h>
 #include <packager/version/version.h>
-#include <filesystem>
 
 namespace shaka {
 namespace hls {

--- a/packager/hls/base/master_playlist_unittest.cc
+++ b/packager/hls/base/master_playlist_unittest.cc
@@ -4,11 +4,14 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+#include <packager/hls/base/master_playlist.h>
+
+#include <filesystem>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <packager/file/file.h>
-#include <packager/hls/base/master_playlist.h>
 #include <packager/hls/base/media_playlist.h>
 #include <packager/hls/base/mock_media_playlist.h>
 #include <packager/version/version.h>

--- a/packager/hls/base/media_playlist.cc
+++ b/packager/hls/base/media_playlist.cc
@@ -6,15 +6,15 @@
 
 #include <packager/hls/base/media_playlist.h>
 
-#include <inttypes.h>
-
 #include <algorithm>
+#include <cinttypes>
 #include <cmath>
 #include <memory>
 
 #include <absl/strings/numbers.h>
 #include <absl/strings/str_format.h>
 #include <glog/logging.h>
+
 #include <packager/file/file.h>
 #include <packager/hls/base/tag.h>
 #include <packager/media/base/language_utils.h>

--- a/packager/hls/base/media_playlist_unittest.cc
+++ b/packager/hls/base/media_playlist_unittest.cc
@@ -4,14 +4,15 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+#include <packager/hls/base/media_playlist.h>
+
+#include <absl/strings/str_format.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <absl/strings/str_format.h>
 #include <packager/file/file.h>
 #include <packager/file/file_closer.h>
 #include <packager/file/file_test_util.h>
-#include <packager/hls/base/media_playlist.h>
 #include <packager/version/version.h>
 
 namespace shaka {

--- a/packager/hls/base/simple_hls_notifier.cc
+++ b/packager/hls/base/simple_hls_notifier.cc
@@ -6,19 +6,20 @@
 
 #include <packager/hls/base/simple_hls_notifier.h>
 
-#include <absl/flags/flag.h>
 #include <cmath>
+#include <filesystem>
+#include <optional>
 
+#include <absl/flags/flag.h>
 #include <absl/strings/escaping.h>
 #include <absl/strings/numbers.h>
 #include <glog/logging.h>
+
 #include <packager/file/file_util.h>
 #include <packager/media/base/protection_system_ids.h>
 #include <packager/media/base/protection_system_specific_info.h>
 #include <packager/media/base/proto_json_util.h>
 #include <packager/media/base/widevine_pssh_data.pb.h>
-#include <filesystem>
-#include <optional>
 
 ABSL_FLAG(bool,
           enable_legacy_widevine_hls_signaling,

--- a/packager/hls/base/simple_hls_notifier_unittest.cc
+++ b/packager/hls/base/simple_hls_notifier_unittest.cc
@@ -4,21 +4,22 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
+#include <packager/hls/base/simple_hls_notifier.h>
+
+#include <filesystem>
+#include <memory>
 
 #include <absl/flags/declare.h>
 #include <absl/flags/flag.h>
-#include <memory>
-
 #include <absl/strings/escaping.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
 #include <packager/flag_saver.h>
 #include <packager/hls/base/mock_media_playlist.h>
-#include <packager/hls/base/simple_hls_notifier.h>
 #include <packager/media/base/protection_system_ids.h>
 #include <packager/media/base/protection_system_specific_info.h>
 #include <packager/media/base/widevine_pssh_data.pb.h>
-#include <filesystem>
 
 ABSL_DECLARE_FLAG(bool, enable_legacy_widevine_hls_signaling);
 

--- a/packager/hls/base/tag.cc
+++ b/packager/hls/base/tag.cc
@@ -6,8 +6,9 @@
 
 #include <packager/hls/base/tag.h>
 
+#include <cinttypes>
+
 #include <absl/strings/str_format.h>
-#include <inttypes.h>
 
 namespace shaka {
 namespace hls {

--- a/packager/kv_pairs/kv_pairs_unittest.cc
+++ b/packager/kv_pairs/kv_pairs_unittest.cc
@@ -4,10 +4,10 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+#include <packager/kv_pairs/kv_pairs.h>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-
-#include <packager/kv_pairs/kv_pairs.h>
 
 namespace shaka {
 

--- a/packager/media/base/aes_cryptor.h
+++ b/packager/media/base/aes_cryptor.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include <mbedtls/cipher.h>
+
 #include <packager/macros.h>
 #include <packager/media/base/fourccs.h>
 

--- a/packager/media/base/aes_cryptor_unittest.cc
+++ b/packager/media/base/aes_cryptor_unittest.cc
@@ -4,15 +4,16 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <gtest/gtest.h>
+#include <packager/media/base/aes_decryptor.h>
+#include <packager/media/base/aes_encryptor.h>
 
 #include <iterator>
 #include <memory>
 
 #include <absl/strings/escaping.h>
 #include <glog/logging.h>
-#include <packager/media/base/aes_decryptor.h>
-#include <packager/media/base/aes_encryptor.h>
+#include <gtest/gtest.h>
+
 #include <packager/utils/bytes_to_string_view.h>
 
 namespace {

--- a/packager/media/base/aes_pattern_cryptor.h
+++ b/packager/media/base/aes_pattern_cryptor.h
@@ -4,11 +4,10 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <packager/media/base/aes_cryptor.h>
-
 #include <memory>
 
 #include <packager/macros.h>
+#include <packager/media/base/aes_cryptor.h>
 
 namespace shaka {
 namespace media {

--- a/packager/media/base/aes_pattern_cryptor_unittest.cc
+++ b/packager/media/base/aes_pattern_cryptor_unittest.cc
@@ -4,11 +4,12 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+#include <packager/media/base/aes_pattern_cryptor.h>
+
+#include <absl/strings/escaping.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <absl/strings/escaping.h>
-#include <packager/media/base/aes_pattern_cryptor.h>
 #include <packager/media/base/mock_aes_cryptor.h>
 
 using ::testing::_;

--- a/packager/media/base/audio_stream_info.cc
+++ b/packager/media/base/audio_stream_info.cc
@@ -6,10 +6,11 @@
 
 #include <packager/media/base/audio_stream_info.h>
 
-#include <inttypes.h>
+#include <cinttypes>
 
 #include <absl/strings/str_format.h>
 #include <glog/logging.h>
+
 #include <packager/macros.h>
 #include <packager/media/base/limits.h>
 

--- a/packager/media/base/audio_timestamp_helper.cc
+++ b/packager/media/base/audio_timestamp_helper.cc
@@ -5,6 +5,7 @@
 #include <packager/media/base/audio_timestamp_helper.h>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/timestamp.h>
 
 namespace shaka {

--- a/packager/media/base/audio_timestamp_helper.h
+++ b/packager/media/base/audio_timestamp_helper.h
@@ -5,7 +5,7 @@
 #ifndef PACKAGER_MEDIA_BASE_AUDIO_TIMESTAMP_HELPER_H_
 #define PACKAGER_MEDIA_BASE_AUDIO_TIMESTAMP_HELPER_H_
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <packager/macros.h>
 

--- a/packager/media/base/audio_timestamp_helper_unittest.cc
+++ b/packager/media/base/audio_timestamp_helper_unittest.cc
@@ -2,11 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <gtest/gtest.h>
+#include <packager/media/base/audio_timestamp_helper.h>
 
 #include <iterator>
 
-#include <packager/media/base/audio_timestamp_helper.h>
+#include <gtest/gtest.h>
+
 #include <packager/media/base/timestamp.h>
 
 namespace shaka {

--- a/packager/media/base/bit_reader.h
+++ b/packager/media/base/bit_reader.h
@@ -5,10 +5,11 @@
 #ifndef PACKAGER_MEDIA_BASE_BIT_READER_H_
 #define PACKAGER_MEDIA_BASE_BIT_READER_H_
 
-#include <stdint.h>
-#include <sys/types.h>
+#include <cstddef>
+#include <cstdint>
 
 #include <glog/logging.h>
+
 #include <packager/macros.h>
 
 namespace shaka {

--- a/packager/media/base/bit_reader_unittest.cc
+++ b/packager/media/base/bit_reader_unittest.cc
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <gtest/gtest.h>
-
 #include <packager/media/base/bit_reader.h>
+
+#include <gtest/gtest.h>
 
 namespace shaka {
 namespace media {

--- a/packager/media/base/bit_writer.h
+++ b/packager/media/base/bit_writer.h
@@ -7,8 +7,7 @@
 #ifndef PACKAGER_MEDIA_BASE_BIT_WRITER_H_
 #define PACKAGER_MEDIA_BASE_BIT_WRITER_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <vector>
 
 #include <glog/logging.h>

--- a/packager/media/base/buffer_reader.h
+++ b/packager/media/base/buffer_reader.h
@@ -7,8 +7,7 @@
 #ifndef PACKAGER_MEDIA_BASE_BUFFER_READER_H_
 #define PACKAGER_MEDIA_BASE_BUFFER_READER_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/packager/media/base/buffer_writer.cc
+++ b/packager/media/base/buffer_writer.cc
@@ -8,6 +8,7 @@
 
 #include <absl/base/internal/endian.h>
 #include <glog/logging.h>
+
 #include <packager/file/file.h>
 
 namespace shaka {

--- a/packager/media/base/buffer_writer_unittest.cc
+++ b/packager/media/base/buffer_writer_unittest.cc
@@ -11,6 +11,7 @@
 #include <memory>
 
 #include <glog/logging.h>
+
 #include <packager/file/file.h>
 #include <packager/file/file_test_util.h>
 #include <packager/media/base/buffer_reader.h>

--- a/packager/media/base/byte_queue.h
+++ b/packager/media/base/byte_queue.h
@@ -5,8 +5,7 @@
 #ifndef PACKAGER_MEDIA_BASE_BYTE_QUEUE_H_
 #define PACKAGER_MEDIA_BASE_BYTE_QUEUE_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <memory>
 
 #include <packager/macros.h>

--- a/packager/media/base/container_names.cc
+++ b/packager/media/base/container_names.cc
@@ -4,16 +4,16 @@
 
 #include <packager/media/base/container_names.h>
 
-#include <libxml/parser.h>
-#include <libxml/tree.h>
-#include <stdint.h>
-
 #include <algorithm>
 #include <cctype>
+#include <cstdint>
 #include <iterator>
 #include <limits>
 
 #include <glog/logging.h>
+#include <libxml/parser.h>
+#include <libxml/tree.h>
+
 #include <packager/media/base/bit_reader.h>
 #include <packager/mpd/base/xml/scoped_xml_ptr.h>
 

--- a/packager/media/base/container_names.h
+++ b/packager/media/base/container_names.h
@@ -5,8 +5,7 @@
 #ifndef PACKAGER_MEDIA_BASE_CONTAINER_NAMES_H_
 #define PACKAGER_MEDIA_BASE_CONTAINER_NAMES_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <string>
 
 namespace shaka {

--- a/packager/media/base/container_names_unittest.cc
+++ b/packager/media/base/container_names_unittest.cc
@@ -2,11 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <gtest/gtest.h>
+#include <packager/media/base/container_names.h>
 
 #include <iterator>
 
-#include <packager/media/base/container_names.h>
+#include <gtest/gtest.h>
+
 #include <packager/media/test/test_data_util.h>
 
 namespace shaka {

--- a/packager/media/base/decrypt_config.h
+++ b/packager/media/base/decrypt_config.h
@@ -5,8 +5,7 @@
 #ifndef PACKAGER_MEDIA_BASE_DECRYPT_CONFIG_H_
 #define PACKAGER_MEDIA_BASE_DECRYPT_CONFIG_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/packager/media/base/decryptor_source.cc
+++ b/packager/media/base/decryptor_source.cc
@@ -7,6 +7,7 @@
 #include <packager/media/base/decryptor_source.h>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/aes_decryptor.h>
 #include <packager/media/base/aes_pattern_cryptor.h>
 

--- a/packager/media/base/decryptor_source_unittest.cc
+++ b/packager/media/base/decryptor_source_unittest.cc
@@ -6,10 +6,10 @@
 
 #include <packager/media/base/decryptor_source.h>
 
+#include <iterator>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-
-#include <iterator>
 
 #include <packager/macros.h>
 #include <packager/media/base/raw_key_source.h>

--- a/packager/media/base/http_key_fetcher_unittest.cc
+++ b/packager/media/base/http_key_fetcher_unittest.cc
@@ -9,6 +9,7 @@
 #include <algorithm>
 
 #include <glog/logging.h>
+
 #include <packager/media/test/test_web_server.h>
 #include <packager/status/status_test_util.h>
 

--- a/packager/media/base/id3_tag.cc
+++ b/packager/media/base/id3_tag.cc
@@ -7,6 +7,7 @@
 #include <packager/media/base/id3_tag.h>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/buffer_writer.h>
 #include <packager/media/base/fourccs.h>
 

--- a/packager/media/base/language_utils.cc
+++ b/packager/media/base/language_utils.cc
@@ -9,6 +9,7 @@
 #include <iterator>
 
 #include <glog/logging.h>
+
 #include <packager/macros.h>
 
 namespace {

--- a/packager/media/base/media_handler_test_base.h
+++ b/packager/media/base/media_handler_test_base.h
@@ -7,11 +7,11 @@
 #ifndef PACKAGER_MEDIA_BASE_MEDIA_HANDLER_TEST_BASE_H_
 #define PACKAGER_MEDIA_BASE_MEDIA_HANDLER_TEST_BASE_H_
 
+#include <absl/strings/escaping.h>
+#include <absl/strings/numbers.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <absl/strings/escaping.h>
-#include <absl/strings/numbers.h>
 #include <packager/media/base/media_handler.h>
 #include <packager/media/base/video_stream_info.h>
 #include <packager/utils/bytes_to_string_view.h>

--- a/packager/media/base/media_sample.cc
+++ b/packager/media/base/media_sample.cc
@@ -6,7 +6,7 @@
 
 #include <packager/media/base/media_sample.h>
 
-#include <inttypes.h>
+#include <cinttypes>
 
 #include <absl/strings/str_format.h>
 #include <glog/logging.h>

--- a/packager/media/base/media_sample.h
+++ b/packager/media/base/media_sample.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/decrypt_config.h>
 
 namespace shaka {

--- a/packager/media/base/muxer_options.h
+++ b/packager/media/base/muxer_options.h
@@ -7,8 +7,7 @@
 #ifndef PACKAGER_MEDIA_BASE_MUXER_OPTIONS_H_
 #define PACKAGER_MEDIA_BASE_MUXER_OPTIONS_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <string>
 
 #include <packager/media/public/mp4_output_params.h>

--- a/packager/media/base/muxer_util.cc
+++ b/packager/media/base/muxer_util.cc
@@ -6,8 +6,7 @@
 
 #include <packager/media/base/muxer_util.h>
 
-#include <inttypes.h>
-
+#include <cinttypes>
 #include <string>
 #include <vector>
 
@@ -15,6 +14,7 @@
 #include <absl/strings/str_format.h>
 #include <absl/strings/str_split.h>
 #include <glog/logging.h>
+
 #include <packager/media/base/video_stream_info.h>
 
 namespace shaka {

--- a/packager/media/base/muxer_util.h
+++ b/packager/media/base/muxer_util.h
@@ -9,7 +9,7 @@
 #ifndef PACKAGER_MEDIA_BASE_MUXER_UTIL_H_
 #define PACKAGER_MEDIA_BASE_MUXER_UTIL_H_
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <packager/status/status.h>
 

--- a/packager/media/base/muxer_util_unittest.cc
+++ b/packager/media/base/muxer_util_unittest.cc
@@ -4,9 +4,9 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <gtest/gtest.h>
-
 #include <packager/media/base/muxer_util.h>
+
+#include <gtest/gtest.h>
 
 namespace shaka {
 namespace media {

--- a/packager/media/base/offset_byte_queue.cc
+++ b/packager/media/base/offset_byte_queue.cc
@@ -4,7 +4,7 @@
 
 #include <packager/media/base/offset_byte_queue.h>
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <glog/logging.h>
 

--- a/packager/media/base/offset_byte_queue.h
+++ b/packager/media/base/offset_byte_queue.h
@@ -5,7 +5,7 @@
 #ifndef PACKAGER_MEDIA_BASE_OFFSET_BYTE_QUEUE_H_
 #define PACKAGER_MEDIA_BASE_OFFSET_BYTE_QUEUE_H_
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <packager/media/base/byte_queue.h>
 

--- a/packager/media/base/offset_byte_queue_unittest.cc
+++ b/packager/media/base/offset_byte_queue_unittest.cc
@@ -2,11 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <gtest/gtest.h>
 #include <packager/media/base/offset_byte_queue.h>
-#include <stdint.h>
-#include <string.h>
+
+#include <cstdint>
+#include <cstring>
 #include <memory>
+
+#include <gtest/gtest.h>
 
 namespace shaka {
 namespace media {

--- a/packager/media/base/playready_key_source.cc
+++ b/packager/media/base/playready_key_source.cc
@@ -11,6 +11,7 @@
 
 #include <absl/strings/escaping.h>
 #include <glog/logging.h>
+
 #include <packager/media/base/buffer_writer.h>
 #include <packager/media/base/http_key_fetcher.h>
 #include <packager/media/base/key_source.h>

--- a/packager/media/base/playready_pssh_generator.cc
+++ b/packager/media/base/playready_pssh_generator.cc
@@ -14,6 +14,7 @@
 #include <absl/strings/escaping.h>
 #include <glog/logging.h>
 #include <mbedtls/cipher.h>
+
 #include <packager/media/base/buffer_writer.h>
 #include <packager/media/base/protection_system_ids.h>
 

--- a/packager/media/base/producer_consumer_queue.h
+++ b/packager/media/base/producer_consumer_queue.h
@@ -13,6 +13,7 @@
 #include <absl/strings/str_format.h>
 #include <absl/synchronization/mutex.h>
 #include <absl/time/time.h>
+
 #include <packager/macros.h>
 #include <packager/status/status.h>
 

--- a/packager/media/base/producer_consumer_queue.h
+++ b/packager/media/base/producer_consumer_queue.h
@@ -13,6 +13,7 @@
 #include <absl/strings/str_format.h>
 #include <absl/synchronization/mutex.h>
 #include <absl/time/time.h>
+#include <glog/logging.h>
 
 #include <packager/macros.h>
 #include <packager/status/status.h>

--- a/packager/media/base/producer_consumer_queue_unittest.cc
+++ b/packager/media/base/producer_consumer_queue_unittest.cc
@@ -4,13 +4,14 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <gtest/gtest.h>
+#include <packager/media/base/producer_consumer_queue.h>
 
 #include <thread>
 
 #include <absl/synchronization/notification.h>
 #include <glog/logging.h>
-#include <packager/media/base/producer_consumer_queue.h>
+#include <gtest/gtest.h>
+
 #include <packager/status/status_test_util.h>
 
 namespace shaka {

--- a/packager/media/base/protection_system_specific_info.h
+++ b/packager/media/base/protection_system_specific_info.h
@@ -7,11 +7,12 @@
 #ifndef PACKAGER_MEDIA_BASE_PROTECTION_SYSTEM_SPECIFIC_INFO_H_
 #define PACKAGER_MEDIA_BASE_PROTECTION_SYSTEM_SPECIFIC_INFO_H_
 
-#include <stdint.h>
+#include <cstdint>
 #include <memory>
 #include <vector>
 
 #include <glog/logging.h>
+
 #include <packager/media/public/crypto_params.h>
 
 namespace shaka {

--- a/packager/media/base/protection_system_specific_info_unittest.cc
+++ b/packager/media/base/protection_system_specific_info_unittest.cc
@@ -4,12 +4,13 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <gtest/gtest.h>
+#include <packager/media/base/protection_system_specific_info.h>
 
 #include <iterator>
 
+#include <gtest/gtest.h>
+
 #include <packager/macros.h>
-#include <packager/media/base/protection_system_specific_info.h>
 
 namespace shaka {
 namespace media {

--- a/packager/media/base/proto_json_util.cc
+++ b/packager/media/base/proto_json_util.cc
@@ -7,7 +7,6 @@
 #include <packager/media/base/proto_json_util.h>
 
 #include <google/protobuf/util/json_util.h>
-
 #include <glog/logging.h>
 
 namespace shaka {

--- a/packager/media/base/pssh_generator_unittest.cc
+++ b/packager/media/base/pssh_generator_unittest.cc
@@ -4,12 +4,13 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
-
 #include <packager/media/base/common_pssh_generator.h>
 #include <packager/media/base/playready_pssh_generator.h>
 #include <packager/media/base/widevine_pssh_generator.h>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
 #include <packager/status/status_test_util.h>
 
 using ::testing::ElementsAreArray;

--- a/packager/media/base/range.h
+++ b/packager/media/base/range.h
@@ -9,7 +9,7 @@
 #ifndef PACKAGER_MEDIA_BASE_RANGE_H_
 #define PACKAGER_MEDIA_BASE_RANGE_H_
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace shaka {
 namespace media {

--- a/packager/media/base/raw_key_source.cc
+++ b/packager/media/base/raw_key_source.cc
@@ -10,6 +10,7 @@
 
 #include <absl/strings/escaping.h>
 #include <glog/logging.h>
+
 #include <packager/media/base/key_source.h>
 #include <packager/status/status_macros.h>
 #include <packager/utils/bytes_to_string_view.h>

--- a/packager/media/base/raw_key_source_unittest.cc
+++ b/packager/media/base/raw_key_source_unittest.cc
@@ -4,11 +4,12 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+#include <packager/media/base/raw_key_source.h>
+
+#include <absl/strings/escaping.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <absl/strings/escaping.h>
-#include <packager/media/base/raw_key_source.h>
 #include <packager/status/status_test_util.h>
 
 #define EXPECT_HEX_EQ(expected_hex, actual)                          \

--- a/packager/media/base/request_signer.cc
+++ b/packager/media/base/request_signer.cc
@@ -8,6 +8,7 @@
 
 #include <glog/logging.h>
 #include <mbedtls/md.h>
+
 #include <packager/media/base/aes_encryptor.h>
 #include <packager/media/base/rsa_key.h>
 

--- a/packager/media/base/rsa_key.h
+++ b/packager/media/base/rsa_key.h
@@ -15,6 +15,7 @@
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/entropy.h>
 #include <mbedtls/pk.h>
+
 #include <packager/macros.h>
 
 namespace shaka {

--- a/packager/media/base/rsa_key_unittest.cc
+++ b/packager/media/base/rsa_key_unittest.cc
@@ -6,12 +6,14 @@
 //
 // Unit test for rsa_key RSA encryption and signing.
 
-#include <gtest/gtest.h>
+#include <packager/media/base/rsa_key.h>
+
 #include <filesystem>
 #include <memory>
 
 #include <glog/logging.h>
-#include <packager/media/base/rsa_key.h>
+#include <gtest/gtest.h>
+
 #include <packager/media/base/test/rsa_test_data.h>
 #include <packager/media/test/test_data_util.h>
 

--- a/packager/media/base/stream_info.cc
+++ b/packager/media/base/stream_info.cc
@@ -6,10 +6,11 @@
 
 #include <packager/media/base/stream_info.h>
 
-#include <inttypes.h>
+#include <cinttypes>
 
 #include <absl/strings/str_format.h>
 #include <glog/logging.h>
+
 #include <packager/macros.h>
 #include <packager/media/base/timestamp.h>
 

--- a/packager/media/base/test/rsa_test_data.cc
+++ b/packager/media/base/test/rsa_test_data.cc
@@ -6,7 +6,7 @@
 
 #include <packager/media/base/test/rsa_test_data.h>
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace {
 const uint8_t kTestRsaPrivateKey_3072[] = {

--- a/packager/media/base/text_sample.h
+++ b/packager/media/base/text_sample.h
@@ -7,8 +7,7 @@
 #ifndef PACKAGER_MEDIA_BASE_TEXT_SAMPLE_H_
 #define PACKAGER_MEDIA_BASE_TEXT_SAMPLE_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <vector>

--- a/packager/media/base/text_stream_info.h
+++ b/packager/media/base/text_stream_info.h
@@ -7,11 +7,11 @@
 #ifndef PACKAGER_MEDIA_BASE_TEXT_STREAM_INFO_H_
 #define PACKAGER_MEDIA_BASE_TEXT_STREAM_INFO_H_
 
-#include <packager/media/base/stream_info.h>
-#include <packager/media/base/text_sample.h>
-
 #include <map>
 #include <string>
+
+#include <packager/media/base/stream_info.h>
+#include <packager/media/base/text_sample.h>
 
 namespace shaka {
 namespace media {

--- a/packager/media/base/timestamp.h
+++ b/packager/media/base/timestamp.h
@@ -7,8 +7,7 @@
 #ifndef PACKAGER_MEDIA_BASE_TIMESTAMP_H_
 #define PACKAGER_MEDIA_BASE_TIMESTAMP_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <limits>
 
 namespace shaka {

--- a/packager/media/base/video_stream_info.cc
+++ b/packager/media/base/video_stream_info.cc
@@ -8,6 +8,7 @@
 
 #include <absl/strings/str_format.h>
 #include <glog/logging.h>
+
 #include <packager/macros.h>
 #include <packager/media/base/limits.h>
 

--- a/packager/media/base/video_util.h
+++ b/packager/media/base/video_util.h
@@ -7,7 +7,7 @@
 #ifndef PACKAGER_MEDIA_BASE_VIDEO_UTIL_H_
 #define PACKAGER_MEDIA_BASE_VIDEO_UTIL_H_
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace shaka {
 namespace media {

--- a/packager/media/base/widevine_key_source.cc
+++ b/packager/media/base/widevine_key_source.cc
@@ -12,6 +12,7 @@
 #include <absl/base/internal/endian.h>
 #include <absl/flags/flag.h>
 #include <absl/strings/escaping.h>
+
 #include <packager/media/base/http_key_fetcher.h>
 #include <packager/media/base/producer_consumer_queue.h>
 #include <packager/media/base/protection_system_ids.h>

--- a/packager/media/base/widevine_key_source.h
+++ b/packager/media/base/widevine_key_source.h
@@ -13,6 +13,7 @@
 
 #include <absl/synchronization/mutex.h>
 #include <absl/synchronization/notification.h>
+
 #include <packager/media/base/fourccs.h>
 #include <packager/media/base/key_source.h>
 

--- a/packager/media/base/widevine_key_source_unittest.cc
+++ b/packager/media/base/widevine_key_source_unittest.cc
@@ -4,19 +4,20 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
-#include <inttypes.h>
+#include <packager/media/base/widevine_key_source.h>
 
 #include <algorithm>
+#include <cinttypes>
 #include <iterator>
 
 #include <absl/strings/escaping.h>
 #include <absl/strings/str_format.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
 #include <packager/media/base/key_fetcher.h>
 #include <packager/media/base/protection_system_ids.h>
 #include <packager/media/base/request_signer.h>
-#include <packager/media/base/widevine_key_source.h>
 #include <packager/media/base/widevine_pssh_generator.h>
 #include <packager/status/status_test_util.h>
 

--- a/packager/media/chunking/chunking_handler.cc
+++ b/packager/media/chunking/chunking_handler.cc
@@ -9,6 +9,7 @@
 #include <algorithm>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/media_sample.h>
 #include <packager/status/status_macros.h>
 

--- a/packager/media/chunking/chunking_handler.h
+++ b/packager/media/chunking/chunking_handler.h
@@ -12,6 +12,7 @@
 #include <queue>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/media_handler.h>
 #include <packager/media/public/chunking_params.h>
 

--- a/packager/media/chunking/sync_point_queue.cc
+++ b/packager/media/chunking/sync_point_queue.cc
@@ -4,11 +4,12 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <packager/media/base/media_handler.h>
 #include <packager/media/chunking/sync_point_queue.h>
 
 #include <algorithm>
 #include <limits>
+
+#include <packager/media/base/media_handler.h>
 
 namespace shaka {
 namespace media {

--- a/packager/media/chunking/sync_point_queue.h
+++ b/packager/media/chunking/sync_point_queue.h
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include <absl/synchronization/mutex.h>
+
 #include <packager/media/public/ad_cue_generator_params.h>
 
 namespace shaka {

--- a/packager/media/codecs/aac_audio_specific_config.cc
+++ b/packager/media/codecs/aac_audio_specific_config.cc
@@ -7,6 +7,7 @@
 #include <algorithm>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/bit_reader.h>
 #include <packager/media/base/rcheck.h>
 

--- a/packager/media/codecs/aac_audio_specific_config.h
+++ b/packager/media/codecs/aac_audio_specific_config.h
@@ -5,9 +5,8 @@
 #ifndef PACKAGER_MEDIA_CODECS_AAC_AUDIO_SPECIFIC_CONFIG_H_
 #define PACKAGER_MEDIA_CODECS_AAC_AUDIO_SPECIFIC_CONFIG_H_
 
-#include <stddef.h>
-#include <stdint.h>
-
+#include <cstddef>
+#include <cstdint>
 #include <vector>
 
 namespace shaka {

--- a/packager/media/codecs/aac_audio_specific_config_unittest.cc
+++ b/packager/media/codecs/aac_audio_specific_config_unittest.cc
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <gtest/gtest.h>
-
 #include <packager/media/codecs/aac_audio_specific_config.h>
+
+#include <gtest/gtest.h>
 
 namespace shaka {
 namespace media {

--- a/packager/media/codecs/ac3_audio_util.cc
+++ b/packager/media/codecs/ac3_audio_util.cc
@@ -7,6 +7,7 @@
 #include <packager/media/codecs/ac3_audio_util.h>
 
 #include <absl/strings/escaping.h>
+
 #include <packager/media/base/bit_reader.h>
 #include <packager/media/base/rcheck.h>
 #include <packager/utils/bytes_to_string_view.h>

--- a/packager/media/codecs/ac3_audio_util.h
+++ b/packager/media/codecs/ac3_audio_util.h
@@ -9,8 +9,8 @@
 #ifndef PACKAGER_MEDIA_CODECS_AC3_AUDIO_UTIL_H_
 #define PACKAGER_MEDIA_CODECS_AC3_AUDIO_UTIL_H_
 
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 #include <vector>
 
 namespace shaka {

--- a/packager/media/codecs/ac3_audio_util_unittest.cc
+++ b/packager/media/codecs/ac3_audio_util_unittest.cc
@@ -4,9 +4,9 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <gtest/gtest.h>
-
 #include <packager/media/codecs/ac3_audio_util.h>
+
+#include <gtest/gtest.h>
 
 namespace shaka {
 namespace media {

--- a/packager/media/codecs/ac4_audio_util.cc
+++ b/packager/media/codecs/ac4_audio_util.cc
@@ -8,6 +8,7 @@
 
 #include <absl/strings/escaping.h>
 #include <absl/strings/str_format.h>
+
 #include <packager/macros.h>
 #include <packager/media/base/bit_reader.h>
 #include <packager/media/base/rcheck.h>

--- a/packager/media/codecs/ac4_audio_util.h
+++ b/packager/media/codecs/ac4_audio_util.h
@@ -9,8 +9,8 @@
 #ifndef PACKAGER_MEDIA_CODECS_AC4_AUDIO_UTIL_H_
 #define PACKAGER_MEDIA_CODECS_AC4_AUDIO_UTIL_H_
 
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 #include <vector>
 
 namespace shaka {

--- a/packager/media/codecs/ac4_audio_util_unittest.cc
+++ b/packager/media/codecs/ac4_audio_util_unittest.cc
@@ -4,9 +4,9 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <gtest/gtest.h>
-
 #include <packager/media/codecs/ac4_audio_util.h>
+
+#include <gtest/gtest.h>
 
 namespace shaka {
 namespace media {

--- a/packager/media/codecs/av1_codec_configuration_record.cc
+++ b/packager/media/codecs/av1_codec_configuration_record.cc
@@ -7,6 +7,7 @@
 #include <packager/media/codecs/av1_codec_configuration_record.h>
 
 #include <absl/strings/str_format.h>
+
 #include <packager/media/base/bit_reader.h>
 #include <packager/media/base/rcheck.h>
 

--- a/packager/media/codecs/av1_codec_configuration_record.h
+++ b/packager/media/codecs/av1_codec_configuration_record.h
@@ -7,7 +7,7 @@
 #ifndef PACKAGER_MEDIA_CODECS_AV1_CODEC_CONFIGURATION_RECORD_H_
 #define PACKAGER_MEDIA_CODECS_AV1_CODEC_CONFIGURATION_RECORD_H_
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/packager/media/codecs/av1_parser.cc
+++ b/packager/media/codecs/av1_parser.cc
@@ -9,6 +9,7 @@
 #include <algorithm>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/bit_reader.h>
 #include <packager/media/base/rcheck.h>
 

--- a/packager/media/codecs/av1_parser.h
+++ b/packager/media/codecs/av1_parser.h
@@ -7,9 +7,8 @@
 #ifndef PACKAGER_MEDIA_CODECS_AV1_PARSER_H_
 #define PACKAGER_MEDIA_CODECS_AV1_PARSER_H_
 
-#include <stdint.h>
-#include <stdlib.h>
-
+#include <cstdint>
+#include <cstdlib>
 #include <vector>
 
 namespace shaka {

--- a/packager/media/codecs/avc_decoder_configuration_record.cc
+++ b/packager/media/codecs/avc_decoder_configuration_record.cc
@@ -8,6 +8,7 @@
 
 #include <absl/strings/ascii.h>
 #include <absl/strings/escaping.h>
+
 #include <packager/macros.h>
 #include <packager/media/base/buffer_reader.h>
 #include <packager/media/base/rcheck.h>

--- a/packager/media/codecs/avc_decoder_configuration_record.h
+++ b/packager/media/codecs/avc_decoder_configuration_record.h
@@ -7,8 +7,7 @@
 #ifndef PACKAGER_MEDIA_CODECS_AVC_DECODER_CONFIGURATION_RECORD_H_
 #define PACKAGER_MEDIA_CODECS_AVC_DECODER_CONFIGURATION_RECORD_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/packager/media/codecs/decoder_configuration_record.h
+++ b/packager/media/codecs/decoder_configuration_record.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include <glog/logging.h>
+
 #include <packager/macros.h>
 #include <packager/media/codecs/nalu_reader.h>
 

--- a/packager/media/codecs/dovi_decoder_configuration_record.cc
+++ b/packager/media/codecs/dovi_decoder_configuration_record.cc
@@ -7,6 +7,7 @@
 #include <packager/media/codecs/dovi_decoder_configuration_record.h>
 
 #include <absl/strings/str_format.h>
+
 #include <packager/media/base/bit_reader.h>
 #include <packager/media/base/rcheck.h>
 

--- a/packager/media/codecs/dovi_decoder_configuration_record.h
+++ b/packager/media/codecs/dovi_decoder_configuration_record.h
@@ -7,7 +7,7 @@
 #ifndef PACKAGER_MEDIA_CODECS_DOVI_DECODER_CONFIGURATION_RECORD_H_
 #define PACKAGER_MEDIA_CODECS_DOVI_DECODER_CONFIGURATION_RECORD_H_
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/packager/media/codecs/ec3_audio_util.cc
+++ b/packager/media/codecs/ec3_audio_util.cc
@@ -7,6 +7,7 @@
 #include <packager/media/codecs/ec3_audio_util.h>
 
 #include <absl/strings/escaping.h>
+
 #include <packager/macros.h>
 #include <packager/media/base/bit_reader.h>
 #include <packager/media/base/rcheck.h>

--- a/packager/media/codecs/ec3_audio_util.h
+++ b/packager/media/codecs/ec3_audio_util.h
@@ -9,8 +9,8 @@
 #ifndef PACKAGER_MEDIA_CODECS_EC3_AUDIO_UTIL_H_
 #define PACKAGER_MEDIA_CODECS_EC3_AUDIO_UTIL_H_
 
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 #include <vector>
 
 namespace shaka {

--- a/packager/media/codecs/ec3_audio_util_unittest.cc
+++ b/packager/media/codecs/ec3_audio_util_unittest.cc
@@ -4,9 +4,9 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <gtest/gtest.h>
-
 #include <packager/media/codecs/ec3_audio_util.h>
+
+#include <gtest/gtest.h>
 
 namespace shaka {
 namespace media {

--- a/packager/media/codecs/es_descriptor.h
+++ b/packager/media/codecs/es_descriptor.h
@@ -5,9 +5,8 @@
 #ifndef PACKAGER_MEDIA_CODECS_ES_DESCRIPTOR_H_
 #define PACKAGER_MEDIA_CODECS_ES_DESCRIPTOR_H_
 
-#include <stddef.h>
-#include <stdint.h>
-
+#include <cstddef>
+#include <cstdint>
 #include <vector>
 
 namespace shaka {

--- a/packager/media/codecs/h264_byte_to_unit_stream_converter.cc
+++ b/packager/media/codecs/h264_byte_to_unit_stream_converter.cc
@@ -9,6 +9,7 @@
 #include <limits>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/buffer_writer.h>
 #include <packager/media/codecs/h264_parser.h>
 

--- a/packager/media/codecs/h264_byte_to_unit_stream_converter.h
+++ b/packager/media/codecs/h264_byte_to_unit_stream_converter.h
@@ -7,9 +7,8 @@
 #ifndef PACKAGER_MEDIA_CODECS_H264_BYTE_TO_UNIT_STREAM_CONVERTER_H_
 #define PACKAGER_MEDIA_CODECS_H264_BYTE_TO_UNIT_STREAM_CONVERTER_H_
 
-#include <stddef.h>
-#include <stdint.h>
-
+#include <cstddef>
+#include <cstdint>
 #include <vector>
 
 #include <packager/media/codecs/h26x_byte_to_unit_stream_converter.h>

--- a/packager/media/codecs/h264_byte_to_unit_stream_converter_unittest.cc
+++ b/packager/media/codecs/h264_byte_to_unit_stream_converter_unittest.cc
@@ -6,9 +6,9 @@
 
 #include <packager/media/codecs/h264_byte_to_unit_stream_converter.h>
 
+#include <absl/strings/escaping.h>
 #include <gtest/gtest.h>
 
-#include <absl/strings/escaping.h>
 #include <packager/media/test/test_data_util.h>
 
 namespace {

--- a/packager/media/codecs/h264_parser.cc
+++ b/packager/media/codecs/h264_parser.cc
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/buffer_reader.h>
 
 #define LOG_ERROR_ONCE(msg)             \

--- a/packager/media/codecs/h264_parser.h
+++ b/packager/media/codecs/h264_parser.h
@@ -7,9 +7,8 @@
 #ifndef PACKAGER_MEDIA_CODECS_H264_PARSER_H_
 #define PACKAGER_MEDIA_CODECS_H264_PARSER_H_
 
-#include <stdint.h>
-#include <stdlib.h>
-
+#include <cstdint>
+#include <cstdlib>
 #include <map>
 #include <memory>
 

--- a/packager/media/codecs/h264_parser_unittest.cc
+++ b/packager/media/codecs/h264_parser_unittest.cc
@@ -1,12 +1,13 @@
 // Copyright 2014 The Chromium Authors. All rights reserved.
+//
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
 #include <packager/media/codecs/h264_parser.h>
 
+#include <glog/logging.h>
 #include <gtest/gtest.h>
 
-#include <glog/logging.h>
 #include <packager/media/test/test_data_util.h>
 
 namespace shaka {

--- a/packager/media/codecs/h265_byte_to_unit_stream_converter.cc
+++ b/packager/media/codecs/h265_byte_to_unit_stream_converter.cc
@@ -9,6 +9,7 @@
 #include <limits>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/buffer_writer.h>
 #include <packager/media/base/rcheck.h>
 #include <packager/media/codecs/h265_parser.h>

--- a/packager/media/codecs/h265_byte_to_unit_stream_converter.h
+++ b/packager/media/codecs/h265_byte_to_unit_stream_converter.h
@@ -7,9 +7,8 @@
 #ifndef PACKAGER_MEDIA_CODECS_H265_BYTE_TO_UNIT_STREAM_CONVERTER_H_
 #define PACKAGER_MEDIA_CODECS_H265_BYTE_TO_UNIT_STREAM_CONVERTER_H_
 
-#include <stddef.h>
-#include <stdint.h>
-
+#include <cstddef>
+#include <cstdint>
 #include <vector>
 
 #include <packager/media/codecs/h26x_byte_to_unit_stream_converter.h>

--- a/packager/media/codecs/h265_byte_to_unit_stream_converter_unittest.cc
+++ b/packager/media/codecs/h265_byte_to_unit_stream_converter_unittest.cc
@@ -6,9 +6,9 @@
 
 #include <packager/media/codecs/h265_byte_to_unit_stream_converter.h>
 
+#include <absl/strings/escaping.h>
 #include <gtest/gtest.h>
 
-#include <absl/strings/escaping.h>
 #include <packager/media/codecs/hevc_decoder_configuration_record.h>
 #include <packager/media/test/test_data_util.h>
 

--- a/packager/media/codecs/h265_parser.cc
+++ b/packager/media/codecs/h265_parser.cc
@@ -6,11 +6,11 @@
 
 #include <packager/media/codecs/h265_parser.h>
 
-#include <math.h>
-
 #include <algorithm>
+#include <cmath>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/macros.h>
 #include <packager/media/codecs/nalu_reader.h>
 

--- a/packager/media/codecs/h265_parser_unittest.cc
+++ b/packager/media/codecs/h265_parser_unittest.cc
@@ -4,9 +4,10 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+#include <packager/media/codecs/h265_parser.h>
+
 #include <gtest/gtest.h>
 
-#include <packager/media/codecs/h265_parser.h>
 #include <packager/media/codecs/nalu_reader.h>
 
 namespace shaka {

--- a/packager/media/codecs/h26x_bit_reader.h
+++ b/packager/media/codecs/h26x_bit_reader.h
@@ -7,8 +7,9 @@
 #ifndef PACKAGER_MEDIA_CODECS_H264_BIT_READER_H_
 #define PACKAGER_MEDIA_CODECS_H264_BIT_READER_H_
 
-#include <stdint.h>
 #include <sys/types.h>
+
+#include <cstdint>
 
 #include <packager/macros.h>
 

--- a/packager/media/codecs/h26x_bit_reader_unittest.cc
+++ b/packager/media/codecs/h26x_bit_reader_unittest.cc
@@ -1,10 +1,11 @@
 // Copyright 2014 The Chromium Authors. All rights reserved.
+//
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <gtest/gtest.h>
-
 #include <packager/media/codecs/h26x_bit_reader.h>
+
+#include <gtest/gtest.h>
 
 namespace shaka {
 namespace media {

--- a/packager/media/codecs/h26x_byte_to_unit_stream_converter.cc
+++ b/packager/media/codecs/h26x_byte_to_unit_stream_converter.cc
@@ -11,6 +11,7 @@
 #include <absl/flags/flag.h>
 #include <absl/strings/escaping.h>
 #include <glog/logging.h>
+
 #include <packager/media/base/buffer_writer.h>
 #include <packager/utils/bytes_to_string_view.h>
 

--- a/packager/media/codecs/h26x_byte_to_unit_stream_converter.h
+++ b/packager/media/codecs/h26x_byte_to_unit_stream_converter.h
@@ -7,8 +7,7 @@
 #ifndef PACKAGER_MEDIA_CODECS_H26X_BYTE_TO_UNIT_STREAM_CONVERTER_H_
 #define PACKAGER_MEDIA_CODECS_H26X_BYTE_TO_UNIT_STREAM_CONVERTER_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <vector>
 
 #include <packager/media/base/video_stream_info.h>

--- a/packager/media/codecs/hevc_decoder_configuration_record.cc
+++ b/packager/media/codecs/hevc_decoder_configuration_record.cc
@@ -9,6 +9,7 @@
 #include <absl/strings/escaping.h>
 #include <absl/strings/str_format.h>
 #include <absl/strings/str_join.h>
+
 #include <packager/media/base/buffer_reader.h>
 #include <packager/media/base/rcheck.h>
 #include <packager/media/codecs/h265_parser.h>

--- a/packager/media/codecs/hevc_decoder_configuration_record.h
+++ b/packager/media/codecs/hevc_decoder_configuration_record.h
@@ -7,8 +7,7 @@
 #ifndef PACKAGER_MEDIA_CODECS_HEVC_DECODER_CONFIGURATION_RECORD_H_
 #define PACKAGER_MEDIA_CODECS_HEVC_DECODER_CONFIGURATION_RECORD_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/packager/media/codecs/nal_unit_to_byte_stream_converter.cc
+++ b/packager/media/codecs/nal_unit_to_byte_stream_converter.cc
@@ -9,6 +9,7 @@
 #include <list>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/bit_reader.h>
 #include <packager/media/base/buffer_reader.h>
 #include <packager/media/base/buffer_writer.h>

--- a/packager/media/codecs/nal_unit_to_byte_stream_converter.h
+++ b/packager/media/codecs/nal_unit_to_byte_stream_converter.h
@@ -7,8 +7,7 @@
 #ifndef PACKAGER_MEDIA_CODECS_NAL_UNIT_TO_BYTE_STREAM_CONVERTER_H_
 #define PACKAGER_MEDIA_CODECS_NAL_UNIT_TO_BYTE_STREAM_CONVERTER_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <vector>
 
 #include <packager/macros.h>

--- a/packager/media/codecs/nal_unit_to_byte_stream_converter_unittest.cc
+++ b/packager/media/codecs/nal_unit_to_byte_stream_converter_unittest.cc
@@ -4,11 +4,12 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+#include <packager/media/codecs/nal_unit_to_byte_stream_converter.h>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <packager/media/base/media_sample.h>
-#include <packager/media/codecs/nal_unit_to_byte_stream_converter.h>
 #include <packager/media/formats/mp4/box_definitions_comparison.h>
 
 namespace shaka {

--- a/packager/media/codecs/nalu_reader.cc
+++ b/packager/media/codecs/nalu_reader.cc
@@ -9,6 +9,7 @@
 #include <iostream>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/buffer_reader.h>
 #include <packager/media/codecs/h264_parser.h>
 

--- a/packager/media/codecs/nalu_reader.h
+++ b/packager/media/codecs/nalu_reader.h
@@ -7,8 +7,8 @@
 #ifndef PACKAGER_MEDIA_CODECS_NALU_READER_H_
 #define PACKAGER_MEDIA_CODECS_NALU_READER_H_
 
-#include <stdint.h>
-#include <stdlib.h>
+#include <cstdint>
+#include <cstdlib>
 
 #include <packager/macros.h>
 #include <packager/media/base/decrypt_config.h>

--- a/packager/media/codecs/vp8_parser.cc
+++ b/packager/media/codecs/vp8_parser.cc
@@ -7,6 +7,7 @@
 #include <packager/media/codecs/vp8_parser.h>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/bit_reader.h>
 #include <packager/media/base/rcheck.h>
 

--- a/packager/media/codecs/vp8_parser.h
+++ b/packager/media/codecs/vp8_parser.h
@@ -7,8 +7,8 @@
 #ifndef PACKAGER_MEDIA_CODECS_VP8_PARSER_H_
 #define PACKAGER_MEDIA_CODECS_VP8_PARSER_H_
 
-#include <stdint.h>
-#include <stdlib.h>
+#include <cstdint>
+#include <cstdlib>
 
 #include <packager/macros.h>
 #include <packager/media/codecs/vpx_parser.h>

--- a/packager/media/codecs/vp9_parser.cc
+++ b/packager/media/codecs/vp9_parser.cc
@@ -7,6 +7,7 @@
 #include <packager/media/codecs/vp9_parser.h>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/bit_reader.h>
 #include <packager/media/base/rcheck.h>
 

--- a/packager/media/codecs/vp9_parser.h
+++ b/packager/media/codecs/vp9_parser.h
@@ -7,8 +7,8 @@
 #ifndef PACKAGER_MEDIA_CODECS_VP9_PARSER_H_
 #define PACKAGER_MEDIA_CODECS_VP9_PARSER_H_
 
-#include <stdint.h>
-#include <stdlib.h>
+#include <cstdint>
+#include <cstdlib>
 
 #include <packager/macros.h>
 #include <packager/media/codecs/vpx_parser.h>

--- a/packager/media/codecs/vp_codec_configuration_record.cc
+++ b/packager/media/codecs/vp_codec_configuration_record.cc
@@ -8,6 +8,7 @@
 
 #include <absl/strings/str_format.h>
 #include <absl/strings/str_replace.h>
+
 #include <packager/media/base/bit_reader.h>
 #include <packager/media/base/buffer_reader.h>
 #include <packager/media/base/buffer_writer.h>

--- a/packager/media/codecs/vp_codec_configuration_record.h
+++ b/packager/media/codecs/vp_codec_configuration_record.h
@@ -7,8 +7,7 @@
 #ifndef PACKAGER_MEDIA_CODECS_VP_CODEC_CONFIGURATION_RECORD_H_
 #define PACKAGER_MEDIA_CODECS_VP_CODEC_CONFIGURATION_RECORD_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <vector>

--- a/packager/media/codecs/vpx_parser.h
+++ b/packager/media/codecs/vpx_parser.h
@@ -7,8 +7,8 @@
 #ifndef PACKAGER_MEDIA_CODECS_VPX_PARSER_H_
 #define PACKAGER_MEDIA_CODECS_VPX_PARSER_H_
 
-#include <stdint.h>
-#include <stdlib.h>
+#include <cstdint>
+#include <cstdlib>
 
 #include <packager/macros.h>
 #include <packager/media/codecs/vp_codec_configuration_record.h>

--- a/packager/media/crypto/encryption_handler.cc
+++ b/packager/media/crypto/encryption_handler.cc
@@ -6,10 +6,9 @@
 
 #include <packager/media/crypto/encryption_handler.h>
 
-#include <stddef.h>
-#include <stdint.h>
-
 #include <algorithm>
+#include <cstddef>
+#include <cstdint>
 
 #include <packager/media/base/aes_encryptor.h>
 #include <packager/media/base/audio_stream_info.h>

--- a/packager/media/crypto/encryption_handler_unittest.cc
+++ b/packager/media/crypto/encryption_handler_unittest.cc
@@ -6,10 +6,10 @@
 
 #include <packager/media/crypto/encryption_handler.h>
 
+#include <glog/logging.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <glog/logging.h>
 #include <packager/media/base/aes_cryptor.h>
 #include <packager/media/base/media_handler_test_base.h>
 #include <packager/media/base/mock_aes_cryptor.h>

--- a/packager/media/crypto/sample_aes_ec3_cryptor.cc
+++ b/packager/media/crypto/sample_aes_ec3_cryptor.cc
@@ -6,8 +6,9 @@
 
 #include <packager/media/crypto/sample_aes_ec3_cryptor.h>
 
-#include <glog/logging.h>
 #include <algorithm>
+
+#include <glog/logging.h>
 
 #include <packager/media/base/buffer_reader.h>
 

--- a/packager/media/crypto/sample_aes_ec3_cryptor.h
+++ b/packager/media/crypto/sample_aes_ec3_cryptor.h
@@ -4,10 +4,10 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <packager/media/base/aes_cryptor.h>
-
 #ifndef PACKAGER_MEDIA_CRYPTO_SAMPLE_AES_EC3_CRYPTOR_H_
 #define PACKAGER_MEDIA_CRYPTO_SAMPLE_AES_EC3_CRYPTOR_H_
+
+#include <packager/media/base/aes_cryptor.h>
 
 namespace shaka {
 namespace media {

--- a/packager/media/demuxer/demuxer.cc
+++ b/packager/media/demuxer/demuxer.cc
@@ -7,11 +7,13 @@
 #include <packager/media/demuxer/demuxer.h>
 
 #include <algorithm>
+#include <functional>
 
 #include <absl/strings/escaping.h>
 #include <absl/strings/numbers.h>
 #include <absl/strings/str_format.h>
 #include <glog/logging.h>
+
 #include <packager/file/file.h>
 #include <packager/media/base/decryptor_source.h>
 #include <packager/media/base/key_source.h>
@@ -23,7 +25,6 @@
 #include <packager/media/formats/webm/webm_media_parser.h>
 #include <packager/media/formats/webvtt/webvtt_parser.h>
 #include <packager/media/formats/wvm/wvm_media_parser.h>
-#include <functional>
 
 namespace {
 // 65KB, sufficient to determine the container and likely all init data.

--- a/packager/media/event/hls_notify_muxer_listener.cc
+++ b/packager/media/event/hls_notify_muxer_listener.cc
@@ -9,6 +9,7 @@
 #include <memory>
 
 #include <glog/logging.h>
+
 #include <packager/hls/base/hls_notifier.h>
 #include <packager/media/base/muxer_options.h>
 #include <packager/media/base/protection_system_specific_info.h>

--- a/packager/media/event/hls_notify_muxer_listener_unittest.cc
+++ b/packager/media/event/hls_notify_muxer_listener_unittest.cc
@@ -4,13 +4,14 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+#include <packager/media/event/hls_notify_muxer_listener.h>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <packager/hls/base/hls_notifier.h>
 #include <packager/media/base/muxer_options.h>
 #include <packager/media/base/protection_system_specific_info.h>
-#include <packager/media/event/hls_notify_muxer_listener.h>
 #include <packager/media/event/muxer_listener_test_helper.h>
 
 namespace shaka {

--- a/packager/media/event/mpd_notify_muxer_listener.cc
+++ b/packager/media/event/mpd_notify_muxer_listener.cc
@@ -9,6 +9,7 @@
 #include <cmath>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/audio_stream_info.h>
 #include <packager/media/base/protection_system_specific_info.h>
 #include <packager/media/base/video_stream_info.h>

--- a/packager/media/event/mpd_notify_muxer_listener_unittest.cc
+++ b/packager/media/event/mpd_notify_muxer_listener_unittest.cc
@@ -6,12 +6,13 @@
 
 #include <packager/media/event/mpd_notify_muxer_listener.h>
 
+#include <algorithm>
+#include <vector>
+
 #include <gmock/gmock.h>
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/message_differencer.h>
 #include <gtest/gtest.h>
-#include <algorithm>
-#include <vector>
 
 #include <packager/media/base/video_stream_info.h>
 #include <packager/media/event/muxer_listener_test_helper.h>

--- a/packager/media/event/multi_codec_muxer_listener.cc
+++ b/packager/media/event/multi_codec_muxer_listener.cc
@@ -8,6 +8,7 @@
 
 #include <absl/strings/str_split.h>
 #include <glog/logging.h>
+
 #include <packager/media/base/stream_info.h>
 
 namespace shaka {

--- a/packager/media/event/muxer_listener.h
+++ b/packager/media/event/muxer_listener.h
@@ -9,8 +9,7 @@
 #ifndef PACKAGER_MEDIA_EVENT_MUXER_LISTENER_H_
 #define PACKAGER_MEDIA_EVENT_MUXER_LISTENER_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <vector>

--- a/packager/media/event/muxer_listener_factory.cc
+++ b/packager/media/event/muxer_listener_factory.cc
@@ -10,6 +10,7 @@
 
 #include <absl/strings/str_format.h>
 #include <glog/logging.h>
+
 #include <packager/hls/base/hls_notifier.h>
 #include <packager/media/event/combined_muxer_listener.h>
 #include <packager/media/event/hls_notify_muxer_listener.h>

--- a/packager/media/event/muxer_listener_internal.cc
+++ b/packager/media/event/muxer_listener_internal.cc
@@ -6,11 +6,12 @@
 
 #include <packager/media/event/muxer_listener_internal.h>
 
-#include <google/protobuf/util/message_differencer.h>
-#include <math.h>
+#include <cmath>
 
 #include <absl/strings/escaping.h>
 #include <glog/logging.h>
+#include <google/protobuf/util/message_differencer.h>
+
 #include <packager/media/base/audio_stream_info.h>
 #include <packager/media/base/muxer_options.h>
 #include <packager/media/base/protection_system_specific_info.h>

--- a/packager/media/event/muxer_listener_internal.h
+++ b/packager/media/event/muxer_listener_internal.h
@@ -7,8 +7,7 @@
 #ifndef PACKAGER_MEDIA_EVENT_MUXER_LISTENER_INTERNAL_H_
 #define PACKAGER_MEDIA_EVENT_MUXER_LISTENER_INTERNAL_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/packager/media/event/muxer_listener_test_helper.cc
+++ b/packager/media/event/muxer_listener_test_helper.cc
@@ -4,10 +4,11 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <packager/media/event/muxer_listener.h>
 #include <packager/media/event/muxer_listener_test_helper.h>
 
 #include <gtest/gtest.h>
+
+#include <packager/media/event/muxer_listener.h>
 
 namespace shaka {
 namespace media {

--- a/packager/media/event/muxer_listener_test_helper.h
+++ b/packager/media/event/muxer_listener_test_helper.h
@@ -7,7 +7,7 @@
 #ifndef PACKAGER_MEDIA_EVENT_MUXER_LISTENER_TEST_HELPER_H_
 #define PACKAGER_MEDIA_EVENT_MUXER_LISTENER_TEST_HELPER_H_
 
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 
 #include <packager/media/base/key_source.h>

--- a/packager/media/event/progress_listener.h
+++ b/packager/media/event/progress_listener.h
@@ -9,7 +9,7 @@
 #ifndef PACKAGER_MEDIA_EVENT_PROGRESS_LISTENER_H_
 #define PACKAGER_MEDIA_EVENT_PROGRESS_LISTENER_H_
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <packager/macros.h>
 

--- a/packager/media/event/vod_media_info_dump_muxer_listener.cc
+++ b/packager/media/event/vod_media_info_dump_muxer_listener.cc
@@ -6,11 +6,11 @@
 
 #include <packager/media/event/vod_media_info_dump_muxer_listener.h>
 
-#include <google/protobuf/text_format.h>
-
 #include <cmath>
 
 #include <glog/logging.h>
+#include <google/protobuf/text_format.h>
+
 #include <packager/file/file.h>
 #include <packager/media/base/muxer_options.h>
 #include <packager/media/base/protection_system_specific_info.h>

--- a/packager/media/event/vod_media_info_dump_muxer_listener_unittest.cc
+++ b/packager/media/event/vod_media_info_dump_muxer_listener_unittest.cc
@@ -6,12 +6,12 @@
 
 #include <packager/media/event/vod_media_info_dump_muxer_listener.h>
 
+#include <vector>
+
 #include <gmock/gmock.h>
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/message_differencer.h>
 #include <gtest/gtest.h>
-
-#include <vector>
 
 #include <packager/file/file.h>
 #include <packager/file/file_test_util.h>

--- a/packager/media/formats/dvb/dvb_sub_parser.cc
+++ b/packager/media/formats/dvb/dvb_sub_parser.cc
@@ -9,6 +9,7 @@
 #include <algorithm>
 
 #include <glog/logging.h>
+
 #include <packager/media/formats/mp2t/mp2t_common.h>
 
 namespace shaka {

--- a/packager/media/formats/dvb/dvb_sub_parser_unittest.cc
+++ b/packager/media/formats/dvb/dvb_sub_parser_unittest.cc
@@ -6,12 +6,12 @@
 
 #include <packager/media/formats/dvb/dvb_sub_parser.h>
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
-
 #include <string>
 #include <utility>
 #include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/dvb/subtitle_composer.cc
+++ b/packager/media/formats/dvb/subtitle_composer.cc
@@ -6,10 +6,10 @@
 
 #include <packager/media/formats/dvb/subtitle_composer.h>
 
-#include <png.h>
-#include <string.h>
+#include <cstring>
 
 #include <glog/logging.h>
+#include <png.h>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/mp2t/ac3_header.h
+++ b/packager/media/formats/mp2t/ac3_header.h
@@ -7,8 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP2T_AC3_HEADER_H_
 #define PACKAGER_MEDIA_FORMATS_MP2T_AC3_HEADER_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <vector>
 
 #include <packager/media/formats/mp2t/audio_header.h>

--- a/packager/media/formats/mp2t/ac3_header_unittest.cc
+++ b/packager/media/formats/mp2t/ac3_header_unittest.cc
@@ -4,14 +4,14 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+#include <packager/media/formats/mp2t/ac3_header.h>
+
+#include <absl/strings/numbers.h>
+#include <glog/logging.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <packager/utils/hex_parser.h>
-
-#include <absl/strings/numbers.h>
-#include <glog/logging.h>
-#include <packager/media/formats/mp2t/ac3_header.h>
 
 using ::testing::ElementsAreArray;
 

--- a/packager/media/formats/mp2t/adts_header.h
+++ b/packager/media/formats/mp2t/adts_header.h
@@ -7,8 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP2T_ADTS_HEADER_H_
 #define PACKAGER_MEDIA_FORMATS_MP2T_ADTS_HEADER_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <vector>
 
 #include <packager/media/formats/mp2t/audio_header.h>

--- a/packager/media/formats/mp2t/adts_header_unittest.cc
+++ b/packager/media/formats/mp2t/adts_header_unittest.cc
@@ -2,11 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <gtest/gtest.h>
+#include <packager/media/formats/mp2t/adts_header.h>
 
 #include <absl/strings/numbers.h>
 #include <glog/logging.h>
-#include <packager/media/formats/mp2t/adts_header.h>
+#include <gtest/gtest.h>
+
 #include <packager/utils/hex_parser.h>
 
 namespace {

--- a/packager/media/formats/mp2t/audio_header.h
+++ b/packager/media/formats/mp2t/audio_header.h
@@ -7,9 +7,8 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP2T_AUDIO_HEADER_H_
 #define PACKAGER_MEDIA_FORMATS_MP2T_AUDIO_HEADER_H_
 
-#include <stddef.h>
-#include <stdint.h>
-
+#include <cstddef>
+#include <cstdint>
 #include <vector>
 
 namespace shaka {

--- a/packager/media/formats/mp2t/es_parser.h
+++ b/packager/media/formats/mp2t/es_parser.h
@@ -5,7 +5,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP2T_ES_PARSER_H_
 #define PACKAGER_MEDIA_FORMATS_MP2T_ES_PARSER_H_
 
-#include <stdint.h>
+#include <cstdint>
 #include <functional>
 
 namespace shaka {

--- a/packager/media/formats/mp2t/es_parser_audio.cc
+++ b/packager/media/formats/mp2t/es_parser_audio.cc
@@ -4,14 +4,14 @@
 
 #include <packager/media/formats/mp2t/es_parser_audio.h>
 
-#include <stdint.h>
-
 #include <algorithm>
+#include <cstdint>
 #include <list>
 
 #include <absl/strings/escaping.h>
 #include <absl/strings/numbers.h>
 #include <glog/logging.h>
+
 #include <packager/media/base/audio_timestamp_helper.h>
 #include <packager/media/base/bit_reader.h>
 #include <packager/media/base/media_sample.h>

--- a/packager/media/formats/mp2t/es_parser_audio.h
+++ b/packager/media/formats/mp2t/es_parser_audio.h
@@ -5,6 +5,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP2T_ES_PARSER_AUDIO_H_
 #define PACKAGER_MEDIA_FORMATS_MP2T_ES_PARSER_AUDIO_H_
 
+#include <functional>
 #include <list>
 #include <memory>
 #include <utility>

--- a/packager/media/formats/mp2t/es_parser_dvb.h
+++ b/packager/media/formats/mp2t/es_parser_dvb.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP2T_ES_PARSER_DVB_H_
 #define PACKAGER_MEDIA_FORMATS_MP2T_ES_PARSER_DVB_H_
 
+#include <functional>
 #include <unordered_map>
 
 #include <packager/media/base/byte_queue.h>

--- a/packager/media/formats/mp2t/es_parser_h264.cc
+++ b/packager/media/formats/mp2t/es_parser_h264.cc
@@ -4,9 +4,10 @@
 
 #include <packager/media/formats/mp2t/es_parser_h264.h>
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/media_sample.h>
 #include <packager/media/base/timestamp.h>
 #include <packager/media/base/video_stream_info.h>

--- a/packager/media/formats/mp2t/es_parser_h264.h
+++ b/packager/media/formats/mp2t/es_parser_h264.h
@@ -5,10 +5,11 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP2T_ES_PARSER_H264_H_
 #define PACKAGER_MEDIA_FORMATS_MP2T_ES_PARSER_H264_H_
 
-#include <packager/media/formats/mp2t/es_parser_h26x.h>
-#include <stdint.h>
+#include <cstdint>
 #include <functional>
 #include <memory>
+
+#include <packager/media/formats/mp2t/es_parser_h26x.h>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/mp2t/es_parser_h264_unittest.cc
+++ b/packager/media/formats/mp2t/es_parser_h264_unittest.cc
@@ -2,19 +2,20 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <gtest/gtest.h>
+#include <packager/media/formats/mp2t/es_parser_h264.h>
 
 #include <algorithm>
+#include <functional>
 #include <vector>
 
 #include <glog/logging.h>
+#include <gtest/gtest.h>
+
 #include <packager/media/base/media_sample.h>
 #include <packager/media/base/timestamp.h>
 #include <packager/media/base/video_stream_info.h>
 #include <packager/media/codecs/h264_parser.h>
-#include <packager/media/formats/mp2t/es_parser_h264.h>
 #include <packager/media/test/test_data_util.h>
-#include <functional>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/mp2t/es_parser_h265.cc
+++ b/packager/media/formats/mp2t/es_parser_h265.cc
@@ -6,9 +6,10 @@
 
 #include <packager/media/formats/mp2t/es_parser_h265.h>
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/media_sample.h>
 #include <packager/media/base/offset_byte_queue.h>
 #include <packager/media/base/timestamp.h>

--- a/packager/media/formats/mp2t/es_parser_h265.h
+++ b/packager/media/formats/mp2t/es_parser_h265.h
@@ -7,8 +7,8 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP2T_ES_PARSER_H265_H_
 #define PACKAGER_MEDIA_FORMATS_MP2T_ES_PARSER_H265_H_
 
-#include <stdint.h>
-
+#include <cstdint>
+#include <functional>
 #include <list>
 #include <memory>
 #include <utility>

--- a/packager/media/formats/mp2t/es_parser_h26x.cc
+++ b/packager/media/formats/mp2t/es_parser_h26x.cc
@@ -4,9 +4,10 @@
 
 #include <packager/media/formats/mp2t/es_parser_h26x.h>
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/media_sample.h>
 #include <packager/media/base/offset_byte_queue.h>
 #include <packager/media/base/timestamp.h>

--- a/packager/media/formats/mp2t/es_parser_h26x.h
+++ b/packager/media/formats/mp2t/es_parser_h26x.h
@@ -5,9 +5,9 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP2T_ES_PARSER_H26x_H_
 #define PACKAGER_MEDIA_FORMATS_MP2T_ES_PARSER_H26x_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <deque>
+#include <functional>
 #include <list>
 #include <memory>
 

--- a/packager/media/formats/mp2t/es_parser_h26x_unittest.cc
+++ b/packager/media/formats/mp2t/es_parser_h26x_unittest.cc
@@ -4,17 +4,18 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <gtest/gtest.h>
+#include <packager/media/formats/mp2t/es_parser_h26x.h>
 
+#include <functional>
 #include <vector>
 
 #include <glog/logging.h>
+#include <gtest/gtest.h>
+
 #include <packager/media/base/media_sample.h>
 #include <packager/media/base/stream_info.h>
 #include <packager/media/base/timestamp.h>
 #include <packager/media/codecs/h26x_byte_to_unit_stream_converter.h>
-#include <packager/media/formats/mp2t/es_parser_h26x.h>
-#include <functional>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/mp2t/mp2t_media_parser.cc
+++ b/packager/media/formats/mp2t/mp2t_media_parser.cc
@@ -4,6 +4,7 @@
 
 #include <packager/media/formats/mp2t/mp2t_media_parser.h>
 
+#include <functional>
 #include <memory>
 
 #include <packager/media/base/media_sample.h>

--- a/packager/media/formats/mp2t/mp2t_media_parser_unittest.cc
+++ b/packager/media/formats/mp2t/mp2t_media_parser_unittest.cc
@@ -2,20 +2,21 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <gtest/gtest.h>
+#include <packager/media/formats/mp2t/mp2t_media_parser.h>
 
 #include <algorithm>
+#include <functional>
 #include <string>
 
 #include <glog/logging.h>
+#include <gtest/gtest.h>
+
 #include <packager/media/base/media_sample.h>
 #include <packager/media/base/stream_info.h>
 #include <packager/media/base/timestamp.h>
 #include <packager/media/base/video_stream_info.h>
 #include <packager/media/formats/mp2t/mp2t_common.h>
-#include <packager/media/formats/mp2t/mp2t_media_parser.h>
 #include <packager/media/test/test_data_util.h>
-#include <functional>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/mp2t/mpeg1_header.cc
+++ b/packager/media/formats/mp2t/mpeg1_header.cc
@@ -1,3 +1,9 @@
+// Copyright 2023 Google LLC. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
 #include <packager/media/formats/mp2t/mpeg1_header.h>
 
 #include <packager/media/base/bit_reader.h>

--- a/packager/media/formats/mp2t/mpeg1_header.h
+++ b/packager/media/formats/mp2t/mpeg1_header.h
@@ -1,8 +1,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP2T_MPEG1_HEADER_H_
 #define PACKAGER_MEDIA_FORMATS_MP2T_MPEG1_HEADER_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <vector>
 
 #include <packager/media/formats/mp2t/audio_header.h>

--- a/packager/media/formats/mp2t/mpeg1_header_unittest.cc
+++ b/packager/media/formats/mp2t/mpeg1_header_unittest.cc
@@ -1,9 +1,16 @@
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
+// Copyright 2023 Google LLC. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+#include <packager/media/formats/mp2t/mpeg1_header.h>
 
 #include <absl/strings/numbers.h>
 #include <glog/logging.h>
-#include <packager/media/formats/mp2t/mpeg1_header.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
 #include <packager/utils/hex_parser.h>
 
 using ::testing::ElementsAreArray;

--- a/packager/media/formats/mp2t/pes_packet.h
+++ b/packager/media/formats/mp2t/pes_packet.h
@@ -7,7 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP2T_PES_PACKET_H_
 #define PACKAGER_MEDIA_FORMATS_MP2T_PES_PACKET_H_
 
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 
 #include <packager/macros.h>

--- a/packager/media/formats/mp2t/pes_packet_generator_unittest.cc
+++ b/packager/media/formats/mp2t/pes_packet_generator_unittest.cc
@@ -4,6 +4,8 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+#include <packager/media/formats/mp2t/pes_packet_generator.h>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -14,7 +16,6 @@
 #include <packager/media/codecs/aac_audio_specific_config.h>
 #include <packager/media/codecs/nal_unit_to_byte_stream_converter.h>
 #include <packager/media/formats/mp2t/pes_packet.h>
-#include <packager/media/formats/mp2t/pes_packet_generator.h>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/mp2t/program_map_table_writer.cc
+++ b/packager/media/formats/mp2t/program_map_table_writer.cc
@@ -10,6 +10,7 @@
 #include <limits>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/buffer_writer.h>
 #include <packager/media/base/fourccs.h>
 #include <packager/media/codecs/hls_audio_util.h>

--- a/packager/media/formats/mp2t/program_map_table_writer.h
+++ b/packager/media/formats/mp2t/program_map_table_writer.h
@@ -7,8 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP2T_PROGRAM_MAP_TABLE_WRITER_H_
 #define PACKAGER_MEDIA_FORMATS_MP2T_PROGRAM_MAP_TABLE_WRITER_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <vector>
 
 #include <packager/media/base/buffer_writer.h>

--- a/packager/media/formats/mp2t/program_map_table_writer_unittest.cc
+++ b/packager/media/formats/mp2t/program_map_table_writer_unittest.cc
@@ -4,13 +4,14 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <gtest/gtest.h>
+#include <packager/media/formats/mp2t/program_map_table_writer.h>
 
 #include <vector>
 
+#include <gtest/gtest.h>
+
 #include <packager/media/base/buffer_writer.h>
 #include <packager/media/formats/mp2t/continuity_counter.h>
-#include <packager/media/formats/mp2t/program_map_table_writer.h>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/mp2t/ts_packet.cc
+++ b/packager/media/formats/mp2t/ts_packet.cc
@@ -4,10 +4,11 @@
 
 #include <packager/media/formats/mp2t/ts_packet.h>
 
+#include <memory>
+
 #include <packager/macros.h>
 #include <packager/media/base/bit_reader.h>
 #include <packager/media/formats/mp2t/mp2t_common.h>
-#include <memory>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/mp2t/ts_packet.h
+++ b/packager/media/formats/mp2t/ts_packet.h
@@ -5,7 +5,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP2T_TS_PACKET_H_
 #define PACKAGER_MEDIA_FORMATS_MP2T_TS_PACKET_H_
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <packager/macros.h>
 

--- a/packager/media/formats/mp2t/ts_packet_writer_util.cc
+++ b/packager/media/formats/mp2t/ts_packet_writer_util.cc
@@ -7,6 +7,7 @@
 #include <packager/media/formats/mp2t/ts_packet_writer_util.h>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/buffer_writer.h>
 #include <packager/media/formats/mp2t/continuity_counter.h>
 

--- a/packager/media/formats/mp2t/ts_packet_writer_util.h
+++ b/packager/media/formats/mp2t/ts_packet_writer_util.h
@@ -9,8 +9,8 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP2T_TS_WRITER_UTIL_H_
 #define PACKAGER_MEDIA_FORMATS_MP2T_TS_WRITER_UTIL_H_
 
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/mp2t/ts_section_pat.cc
+++ b/packager/media/formats/mp2t/ts_section_pat.cc
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/bit_reader.h>
 #include <packager/media/formats/mp2t/mp2t_common.h>
 

--- a/packager/media/formats/mp2t/ts_section_pat.h
+++ b/packager/media/formats/mp2t/ts_section_pat.h
@@ -5,9 +5,10 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP2T_TS_SECTION_PAT_H_
 #define PACKAGER_MEDIA_FORMATS_MP2T_TS_SECTION_PAT_H_
 
+#include <functional>
+
 #include <packager/macros.h>
 #include <packager/media/formats/mp2t/ts_section_psi.h>
-#include <functional>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/mp2t/ts_section_pes.cc
+++ b/packager/media/formats/mp2t/ts_section_pes.cc
@@ -5,6 +5,7 @@
 #include <packager/media/formats/mp2t/ts_section_pes.h>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/bit_reader.h>
 #include <packager/media/base/timestamp.h>
 #include <packager/media/formats/mp2t/es_parser.h>

--- a/packager/media/formats/mp2t/ts_section_pes.h
+++ b/packager/media/formats/mp2t/ts_section_pes.h
@@ -5,11 +5,12 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP2T_TS_SECTION_PES_H_
 #define PACKAGER_MEDIA_FORMATS_MP2T_TS_SECTION_PES_H_
 
+#include <cstdint>
+#include <memory>
+
 #include <packager/macros.h>
 #include <packager/media/base/byte_queue.h>
 #include <packager/media/formats/mp2t/ts_section.h>
-#include <stdint.h>
-#include <memory>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/mp2t/ts_section_pmt.cc
+++ b/packager/media/formats/mp2t/ts_section_pmt.cc
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/bit_reader.h>
 #include <packager/media/formats/mp2t/mp2t_common.h>
 #include <packager/media/formats/mp2t/ts_stream_type.h>

--- a/packager/media/formats/mp2t/ts_section_pmt.h
+++ b/packager/media/formats/mp2t/ts_section_pmt.h
@@ -5,10 +5,11 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP2T_TS_SECTION_PMT_H_
 #define PACKAGER_MEDIA_FORMATS_MP2T_TS_SECTION_PMT_H_
 
+#include <functional>
+
 #include <packager/macros.h>
 #include <packager/media/formats/mp2t/ts_section_psi.h>
 #include <packager/media/formats/mp2t/ts_stream_type.h>
-#include <functional>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/mp2t/ts_section_psi.cc
+++ b/packager/media/formats/mp2t/ts_section_psi.cc
@@ -4,11 +4,11 @@
 
 #include <packager/media/formats/mp2t/ts_section_psi.h>
 
-#include <stdint.h>
-
 #include <algorithm>
+#include <cstdint>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/bit_reader.h>
 #include <packager/media/formats/mp2t/mp2t_common.h>
 

--- a/packager/media/formats/mp2t/ts_segmenter.h
+++ b/packager/media/formats/mp2t/ts_segmenter.h
@@ -7,12 +7,13 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP2T_TS_SEGMENTER_H_
 #define PACKAGER_MEDIA_FORMATS_MP2T_TS_SEGMENTER_H_
 
+#include <memory>
+
 #include <packager/file/file.h>
 #include <packager/media/base/muxer_options.h>
 #include <packager/media/formats/mp2t/pes_packet_generator.h>
 #include <packager/media/formats/mp2t/ts_writer.h>
 #include <packager/status/status.h>
-#include <memory>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/mp2t/ts_segmenter_unittest.cc
+++ b/packager/media/formats/mp2t/ts_segmenter_unittest.cc
@@ -4,6 +4,8 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+#include <packager/media/formats/mp2t/ts_segmenter.h>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -13,7 +15,6 @@
 #include <packager/media/event/mock_muxer_listener.h>
 #include <packager/media/formats/mp2t/pes_packet.h>
 #include <packager/media/formats/mp2t/program_map_table_writer.h>
-#include <packager/media/formats/mp2t/ts_segmenter.h>
 #include <packager/status/status_test_util.h>
 
 namespace shaka {

--- a/packager/media/formats/mp2t/ts_stream_type.h
+++ b/packager/media/formats/mp2t/ts_stream_type.h
@@ -7,7 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP2T_TS_STREAM_TYPE_H_
 #define PACKAGER_MEDIA_FORMATS_MP2T_TS_STREAM_TYPE_H_
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/mp2t/ts_writer.cc
+++ b/packager/media/formats/mp2t/ts_writer.cc
@@ -9,6 +9,7 @@
 #include <algorithm>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/buffer_writer.h>
 #include <packager/media/base/media_sample.h>
 #include <packager/media/formats/mp2t/pes_packet.h>

--- a/packager/media/formats/mp2t/ts_writer.h
+++ b/packager/media/formats/mp2t/ts_writer.h
@@ -10,6 +10,7 @@
 #include <list>
 #include <map>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include <packager/file/file.h>

--- a/packager/media/formats/mp2t/ts_writer_unittest.cc
+++ b/packager/media/formats/mp2t/ts_writer_unittest.cc
@@ -4,6 +4,10 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+#include <packager/media/formats/mp2t/ts_writer.h>
+
+#include <filesystem>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -12,7 +16,6 @@
 #include <packager/media/base/video_stream_info.h>
 #include <packager/media/formats/mp2t/pes_packet.h>
 #include <packager/media/formats/mp2t/program_map_table_writer.h>
-#include <packager/media/formats/mp2t/ts_writer.h>
 #include <filesystem>
 
 using ::testing::InSequence;

--- a/packager/media/formats/mp4/box.cc
+++ b/packager/media/formats/mp4/box.cc
@@ -7,6 +7,7 @@
 #include <packager/media/formats/mp4/box.h>
 
 #include <glog/logging.h>
+
 #include <packager/media/formats/mp4/box_buffer.h>
 
 namespace shaka {

--- a/packager/media/formats/mp4/box.h
+++ b/packager/media/formats/mp4/box.h
@@ -7,7 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP4_BOX_H_
 #define PACKAGER_MEDIA_FORMATS_MP4_BOX_H_
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <packager/media/base/fourccs.h>
 

--- a/packager/media/formats/mp4/box_definitions.cc
+++ b/packager/media/formats/mp4/box_definitions.cc
@@ -4,11 +4,12 @@
 
 #include <packager/media/formats/mp4/box_definitions.h>
 
-#include <absl/flags/flag.h>
 #include <algorithm>
 #include <limits>
 
+#include <absl/flags/flag.h>
 #include <glog/logging.h>
+
 #include <packager/media/base/bit_reader.h>
 #include <packager/media/base/macros.h>
 #include <packager/media/base/rcheck.h>

--- a/packager/media/formats/mp4/box_definitions_unittest.cc
+++ b/packager/media/formats/mp4/box_definitions_unittest.cc
@@ -4,14 +4,15 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <gtest/gtest.h>
+#include <packager/media/formats/mp4/box_definitions.h>
 
 #include <limits>
 #include <memory>
 
+#include <gtest/gtest.h>
+
 #include <packager/media/base/buffer_writer.h>
 #include <packager/media/base/protection_system_specific_info.h>
-#include <packager/media/formats/mp4/box_definitions.h>
 #include <packager/media/formats/mp4/box_definitions_comparison.h>
 #include <packager/media/formats/mp4/box_reader.h>
 

--- a/packager/media/formats/mp4/box_reader.cc
+++ b/packager/media/formats/mp4/box_reader.cc
@@ -4,13 +4,13 @@
 
 #include <packager/media/formats/mp4/box_reader.h>
 
-#include <inttypes.h>
-
+#include <cinttypes>
 #include <limits>
 #include <memory>
 
 #include <absl/strings/str_format.h>
 #include <glog/logging.h>
+
 #include <packager/media/formats/mp4/box.h>
 
 namespace shaka {

--- a/packager/media/formats/mp4/box_reader.h
+++ b/packager/media/formats/mp4/box_reader.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include <glog/logging.h>
+
 #include <packager/macros.h>
 #include <packager/media/base/buffer_reader.h>
 #include <packager/media/base/fourccs.h>

--- a/packager/media/formats/mp4/box_reader_unittest.cc
+++ b/packager/media/formats/mp4/box_reader_unittest.cc
@@ -2,15 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <gtest/gtest.h>
-#include <stdint.h>
-#include <string.h>
+#include <packager/media/formats/mp4/box_buffer.h>
 
+#include <cstdint>
+#include <cstring>
 #include <memory>
 
 #include <glog/logging.h>
+#include <gtest/gtest.h>
+
 #include <packager/media/base/rcheck.h>
-#include <packager/media/formats/mp4/box_buffer.h>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/mp4/chunk_info_iterator.h
+++ b/packager/media/formats/mp4/chunk_info_iterator.h
@@ -7,8 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP4_CHUNK_INFO_ITERATOR_H_
 #define PACKAGER_MEDIA_FORMATS_MP4_CHUNK_INFO_ITERATOR_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <vector>
 
 #include <packager/macros.h>

--- a/packager/media/formats/mp4/chunk_info_iterator_unittest.cc
+++ b/packager/media/formats/mp4/chunk_info_iterator_unittest.cc
@@ -4,10 +4,12 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+#include <packager/media/formats/mp4/chunk_info_iterator.h>
+
+#include <memory>
+
 #include <glog/logging.h>
 #include <gtest/gtest.h>
-#include <packager/media/formats/mp4/chunk_info_iterator.h>
-#include <memory>
 
 namespace {
 struct ChunkProperty {

--- a/packager/media/formats/mp4/composition_offset_iterator.h
+++ b/packager/media/formats/mp4/composition_offset_iterator.h
@@ -7,8 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP4_COMPOSITION_OFFSET_ITERATOR_H_
 #define PACKAGER_MEDIA_FORMATS_MP4_COMPOSITION_OFFSET_ITERATOR_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <vector>
 
 #include <packager/macros.h>

--- a/packager/media/formats/mp4/composition_offset_iterator_unittest.cc
+++ b/packager/media/formats/mp4/composition_offset_iterator_unittest.cc
@@ -4,9 +4,11 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <gtest/gtest.h>
 #include <packager/media/formats/mp4/composition_offset_iterator.h>
+
 #include <memory>
+
+#include <gtest/gtest.h>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/mp4/decoding_time_iterator.h
+++ b/packager/media/formats/mp4/decoding_time_iterator.h
@@ -7,8 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP4_DECODING_TIME_ITERATOR_H_
 #define PACKAGER_MEDIA_FORMATS_MP4_DECODING_TIME_ITERATOR_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <vector>
 
 #include <packager/macros.h>

--- a/packager/media/formats/mp4/decoding_time_iterator_unittest.cc
+++ b/packager/media/formats/mp4/decoding_time_iterator_unittest.cc
@@ -4,9 +4,11 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <gtest/gtest.h>
 #include <packager/media/formats/mp4/decoding_time_iterator.h>
+
 #include <memory>
+
+#include <gtest/gtest.h>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/mp4/fragmenter.h
+++ b/packager/media/formats/mp4/fragmenter.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include <glog/logging.h>
+
 #include <packager/macros.h>
 #include <packager/status/status.h>
 

--- a/packager/media/formats/mp4/low_latency_segment_segmenter.h
+++ b/packager/media/formats/mp4/low_latency_segment_segmenter.h
@@ -7,10 +7,9 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP4_LOW_LATENCY_SEGMENT_SEGMENTER_H_
 #define PACKAGER_MEDIA_FORMATS_MP4_LOW_LATENCY_SEGMENT_SEGMENTER_H_
 
-#include <packager/media/formats/mp4/segmenter.h>
-
 #include <packager/file/file.h>
 #include <packager/file/file_closer.h>
+#include <packager/media/formats/mp4/segmenter.h>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/mp4/mp4_media_parser.cc
+++ b/packager/media/formats/mp4/mp4_media_parser.cc
@@ -5,10 +5,12 @@
 #include <packager/media/formats/mp4/mp4_media_parser.h>
 
 #include <algorithm>
+#include <functional>
 #include <limits>
 
 #include <absl/strings/numbers.h>
 #include <glog/logging.h>
+
 #include <packager/file/file.h>
 #include <packager/file/file_closer.h>
 #include <packager/media/base/audio_stream_info.h>
@@ -32,7 +34,6 @@
 #include <packager/media/formats/mp4/box_definitions.h>
 #include <packager/media/formats/mp4/box_reader.h>
 #include <packager/media/formats/mp4/track_run_iterator.h>
-#include <functional>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/mp4/mp4_media_parser.h
+++ b/packager/media/formats/mp4/mp4_media_parser.h
@@ -7,8 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP4_MP4_MEDIA_PARSER_H_
 #define PACKAGER_MEDIA_FORMATS_MP4_MP4_MEDIA_PARSER_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <vector>

--- a/packager/media/formats/mp4/mp4_media_parser_unittest.cc
+++ b/packager/media/formats/mp4/mp4_media_parser_unittest.cc
@@ -4,17 +4,19 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+#include <packager/media/formats/mp4/mp4_media_parser.h>
+
+#include <functional>
+
+#include <glog/logging.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <glog/logging.h>
 #include <packager/media/base/media_sample.h>
 #include <packager/media/base/raw_key_source.h>
 #include <packager/media/base/stream_info.h>
 #include <packager/media/base/video_stream_info.h>
-#include <packager/media/formats/mp4/mp4_media_parser.h>
 #include <packager/media/test/test_data_util.h>
-#include <functional>
 
 using ::testing::_;
 using ::testing::DoAll;

--- a/packager/media/formats/mp4/mp4_muxer.cc
+++ b/packager/media/formats/mp4/mp4_muxer.cc
@@ -7,9 +7,11 @@
 #include <packager/media/formats/mp4/mp4_muxer.h>
 
 #include <algorithm>
+#include <chrono>
 
 #include <absl/strings/escaping.h>
 #include <absl/strings/numbers.h>
+
 #include <packager/file/file.h>
 #include <packager/media/base/aes_encryptor.h>
 #include <packager/media/base/audio_stream_info.h>
@@ -26,7 +28,6 @@
 #include <packager/media/formats/mp4/single_segment_segmenter.h>
 #include <packager/media/formats/ttml/ttml_generator.h>
 #include <packager/status/status_macros.h>
-#include <chrono>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/mp4/mp4_muxer.h
+++ b/packager/media/formats/mp4/mp4_muxer.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP4_MP4_MUXER_H_
 #define PACKAGER_MEDIA_FORMATS_MP4_MP4_MUXER_H_
 
+#include <optional>
 #include <vector>
 
 #include <packager/media/base/muxer.h>

--- a/packager/media/formats/mp4/multi_segment_segmenter.cc
+++ b/packager/media/formats/mp4/multi_segment_segmenter.cc
@@ -10,6 +10,7 @@
 
 #include <absl/strings/numbers.h>
 #include <absl/strings/str_format.h>
+
 #include <packager/file/file.h>
 #include <packager/file/file_closer.h>
 #include <packager/media/base/buffer_writer.h>

--- a/packager/media/formats/mp4/segmenter.cc
+++ b/packager/media/formats/mp4/segmenter.cc
@@ -9,6 +9,7 @@
 #include <algorithm>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/buffer_writer.h>
 #include <packager/media/base/id3_tag.h>
 #include <packager/media/base/media_sample.h>

--- a/packager/media/formats/mp4/segmenter.h
+++ b/packager/media/formats/mp4/segmenter.h
@@ -9,6 +9,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include <packager/media/base/fourccs.h>

--- a/packager/media/formats/mp4/sync_sample_iterator.h
+++ b/packager/media/formats/mp4/sync_sample_iterator.h
@@ -7,8 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP4_SYNC_SAMPLE_ITERATOR_H_
 #define PACKAGER_MEDIA_FORMATS_MP4_SYNC_SAMPLE_ITERATOR_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <vector>
 
 #include <packager/macros.h>

--- a/packager/media/formats/mp4/sync_sample_iterator_unittest.cc
+++ b/packager/media/formats/mp4/sync_sample_iterator_unittest.cc
@@ -4,9 +4,9 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <gtest/gtest.h>
-
 #include <packager/media/formats/mp4/sync_sample_iterator.h>
+
+#include <gtest/gtest.h>
 
 namespace {
 const uint32_t kNumSamples = 100;

--- a/packager/media/formats/mp4/track_run_iterator.cc
+++ b/packager/media/formats/mp4/track_run_iterator.cc
@@ -4,16 +4,10 @@
 
 #include <packager/media/formats/mp4/track_run_iterator.h>
 
-#include <absl/flags/flag.h>
-
-ABSL_FLAG(bool,
-          mp4_reset_initial_composition_offset_to_zero,
-          true,
-          "MP4 only. If it is true, reset the initial composition offset to "
-          "zero, i.e. by assuming that there is a missing EditList.");
-
 #include <algorithm>
 #include <limits>
+
+#include <absl/flags/flag.h>
 
 #include <packager/media/base/buffer_reader.h>
 #include <packager/media/base/fourccs.h>
@@ -22,6 +16,12 @@ ABSL_FLAG(bool,
 #include <packager/media/formats/mp4/composition_offset_iterator.h>
 #include <packager/media/formats/mp4/decoding_time_iterator.h>
 #include <packager/media/formats/mp4/sync_sample_iterator.h>
+
+ABSL_FLAG(bool,
+          mp4_reset_initial_composition_offset_to_zero,
+          true,
+          "MP4 only. If it is true, reset the initial composition offset to "
+          "zero, i.e. by assuming that there is a missing EditList.");
 
 namespace {
 const int64_t kInvalidOffset = std::numeric_limits<int64_t>::max();

--- a/packager/media/formats/mp4/track_run_iterator_unittest.cc
+++ b/packager/media/formats/mp4/track_run_iterator_unittest.cc
@@ -4,14 +4,16 @@
 
 #include <packager/media/formats/mp4/track_run_iterator.h>
 
+#include <cstdint>
+#include <memory>
+
 #include <absl/flags/declare.h>
 #include <absl/flags/flag.h>
 #include <glog/logging.h>
 #include <gtest/gtest.h>
+
 #include <packager/flag_saver.h>
 #include <packager/media/formats/mp4/box_definitions.h>
-#include <stdint.h>
-#include <memory>
 
 ABSL_DECLARE_FLAG(bool, mp4_reset_initial_composition_offset_to_zero);
 

--- a/packager/media/formats/ttml/ttml_generator.cc
+++ b/packager/media/formats/ttml/ttml_generator.cc
@@ -8,6 +8,7 @@
 
 #include <absl/strings/escaping.h>
 #include <absl/strings/str_format.h>
+
 #include <packager/media/base/rcheck.h>
 
 namespace shaka {

--- a/packager/media/formats/webm/cluster_builder.cc
+++ b/packager/media/formats/webm/cluster_builder.cc
@@ -5,6 +5,7 @@
 #include <packager/media/formats/webm/cluster_builder.h>
 
 #include <glog/logging.h>
+
 #include <packager/media/formats/webm/webm_constants.h>
 
 namespace shaka {

--- a/packager/media/formats/webm/cluster_builder.h
+++ b/packager/media/formats/webm/cluster_builder.h
@@ -5,8 +5,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_WEBM_CLUSTER_BUILDER_H_
 #define PACKAGER_MEDIA_FORMATS_WEBM_CLUSTER_BUILDER_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <memory>
 
 #include <packager/macros.h>

--- a/packager/media/formats/webm/encrypted_segmenter_unittest.cc
+++ b/packager/media/formats/webm/encrypted_segmenter_unittest.cc
@@ -4,9 +4,11 @@
 
 #include <packager/media/formats/webm/two_pass_single_segment_segmenter.h>
 
-#include <gtest/gtest.h>
-#include <packager/media/formats/webm/segmenter_test_base.h>
 #include <memory>
+
+#include <gtest/gtest.h>
+
+#include <packager/media/formats/webm/segmenter_test_base.h>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/webm/encryptor.h
+++ b/packager/media/formats/webm/encryptor.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include <mkvmuxer/mkvmuxer.h>
+
 #include <packager/status/status.h>
 
 namespace shaka {

--- a/packager/media/formats/webm/encryptor_unittest.cc
+++ b/packager/media/formats/webm/encryptor_unittest.cc
@@ -6,9 +6,9 @@
 
 #include <packager/media/formats/webm/encryptor.h>
 
-#include <gtest/gtest.h>
-
 #include <memory>
+
+#include <gtest/gtest.h>
 
 #include <packager/media/base/media_sample.h>
 #include <packager/media/formats/webm/webm_constants.h>

--- a/packager/media/formats/webm/mkv_writer.h
+++ b/packager/media/formats/webm/mkv_writer.h
@@ -11,6 +11,7 @@
 #include <string>
 
 #include <mkvmuxer/mkvmuxer.h>
+
 #include <packager/file/file_closer.h>
 #include <packager/status/status.h>
 

--- a/packager/media/formats/webm/multi_segment_segmenter.cc
+++ b/packager/media/formats/webm/multi_segment_segmenter.cc
@@ -7,6 +7,7 @@
 #include <packager/media/formats/webm/multi_segment_segmenter.h>
 
 #include <mkvmuxer/mkvmuxer.h>
+
 #include <packager/media/base/muxer_options.h>
 #include <packager/media/base/muxer_util.h>
 #include <packager/media/base/stream_info.h>

--- a/packager/media/formats/webm/multi_segment_segmenter_unittest.cc
+++ b/packager/media/formats/webm/multi_segment_segmenter_unittest.cc
@@ -4,10 +4,12 @@
 
 #include <packager/media/formats/webm/multi_segment_segmenter.h>
 
+#include <memory>
+
 #include <gtest/gtest.h>
+
 #include <packager/media/base/muxer_util.h>
 #include <packager/media/formats/webm/segmenter_test_base.h>
-#include <memory>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/webm/seek_head.h
+++ b/packager/media/formats/webm/seek_head.h
@@ -7,8 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_WEBM_SEEK_HEAD_H_
 #define PACKAGER_MEDIA_FORMATS_WEBM_SEEK_HEAD_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <vector>
 
 #include <mkvmuxer/mkvmuxer.h>

--- a/packager/media/formats/webm/segmenter.cc
+++ b/packager/media/formats/webm/segmenter.cc
@@ -7,6 +7,7 @@
 #include <packager/media/formats/webm/segmenter.h>
 
 #include <mkvmuxer/mkvmuxerutil.h>
+
 #include <packager/media/base/audio_stream_info.h>
 #include <packager/media/base/media_handler.h>
 #include <packager/media/base/muxer_options.h>

--- a/packager/media/formats/webm/segmenter.h
+++ b/packager/media/formats/webm/segmenter.h
@@ -10,6 +10,7 @@
 #include <memory>
 
 #include <mkvmuxer/mkvmuxer.h>
+
 #include <packager/media/base/range.h>
 #include <packager/media/formats/webm/mkv_writer.h>
 #include <packager/media/formats/webm/seek_head.h>

--- a/packager/media/formats/webm/single_segment_segmenter.cc
+++ b/packager/media/formats/webm/single_segment_segmenter.cc
@@ -7,6 +7,7 @@
 #include <packager/media/formats/webm/single_segment_segmenter.h>
 
 #include <mkvmuxer/mkvmuxer.h>
+
 #include <packager/media/base/muxer_options.h>
 #include <packager/media/event/muxer_listener.h>
 

--- a/packager/media/formats/webm/single_segment_segmenter_unittest.cc
+++ b/packager/media/formats/webm/single_segment_segmenter_unittest.cc
@@ -4,9 +4,11 @@
 
 #include <packager/media/formats/webm/two_pass_single_segment_segmenter.h>
 
-#include <gtest/gtest.h>
-#include <packager/media/formats/webm/segmenter_test_base.h>
 #include <memory>
+
+#include <gtest/gtest.h>
+
+#include <packager/media/formats/webm/segmenter_test_base.h>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/webm/tracks_builder.cc
+++ b/packager/media/formats/webm/tracks_builder.cc
@@ -5,6 +5,7 @@
 #include <packager/media/formats/webm/tracks_builder.h>
 
 #include <glog/logging.h>
+
 #include <packager/media/formats/webm/webm_constants.h>
 
 namespace shaka {

--- a/packager/media/formats/webm/tracks_builder.h
+++ b/packager/media/formats/webm/tracks_builder.h
@@ -5,8 +5,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_WEBM_TRACKS_BUILDER_H_
 #define PACKAGER_MEDIA_FORMATS_WEBM_TRACKS_BUILDER_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <list>
 #include <string>
 #include <vector>

--- a/packager/media/formats/webm/two_pass_single_segment_segmenter.cc
+++ b/packager/media/formats/webm/two_pass_single_segment_segmenter.cc
@@ -10,6 +10,7 @@
 
 #include <mkvmuxer/mkvmuxer.h>
 #include <mkvmuxer/mkvmuxerutil.h>
+
 #include <packager/file/file_util.h>
 #include <packager/media/base/media_sample.h>
 #include <packager/media/base/muxer_options.h>

--- a/packager/media/formats/webm/webm_audio_client.cc
+++ b/packager/media/formats/webm/webm_audio_client.cc
@@ -5,6 +5,7 @@
 #include <packager/media/formats/webm/webm_audio_client.h>
 
 #include <glog/logging.h>
+
 #include <packager/media/formats/webm/webm_constants.h>
 
 namespace {

--- a/packager/media/formats/webm/webm_cluster_parser.cc
+++ b/packager/media/formats/webm/webm_cluster_parser.cc
@@ -9,6 +9,7 @@
 
 #include <absl/base/internal/endian.h>
 #include <glog/logging.h>
+
 #include <packager/media/base/timestamp.h>
 #include <packager/media/codecs/vp8_parser.h>
 #include <packager/media/codecs/vp9_parser.h>

--- a/packager/media/formats/webm/webm_cluster_parser_unittest.cc
+++ b/packager/media/formats/webm/webm_cluster_parser_unittest.cc
@@ -4,9 +4,6 @@
 
 #include <packager/media/formats/webm/webm_cluster_parser.h>
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
-
 #include <algorithm>
 #include <cstdlib>
 #include <functional>
@@ -15,6 +12,9 @@
 
 #include <absl/strings/str_format.h>
 #include <glog/logging.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
 #include <packager/media/base/decrypt_config.h>
 #include <packager/media/base/raw_key_source.h>
 #include <packager/media/base/timestamp.h>

--- a/packager/media/formats/webm/webm_constants.h
+++ b/packager/media/formats/webm/webm_constants.h
@@ -5,8 +5,8 @@
 #ifndef PACKAGER_MEDIA_FORMATS_WEBM_WEBM_CONSTANTS_H_
 #define PACKAGER_MEDIA_FORMATS_WEBM_WEBM_CONSTANTS_H_
 
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/webm/webm_content_encodings.h
+++ b/packager/media/formats/webm/webm_content_encodings.h
@@ -5,7 +5,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_WEBM_WEBM_CONTENT_ENCODINGS_H_
 #define PACKAGER_MEDIA_FORMATS_WEBM_WEBM_CONTENT_ENCODINGS_H_
 
-#include <stdint.h>
+#include <cstdint>
 #include <memory>
 #include <string>
 

--- a/packager/media/formats/webm/webm_content_encodings_client.cc
+++ b/packager/media/formats/webm/webm_content_encodings_client.cc
@@ -5,6 +5,7 @@
 #include <packager/media/formats/webm/webm_content_encodings_client.h>
 
 #include <glog/logging.h>
+
 #include <packager/media/formats/webm/webm_constants.h>
 
 namespace shaka {

--- a/packager/media/formats/webm/webm_content_encodings_client_unittest.cc
+++ b/packager/media/formats/webm/webm_content_encodings_client_unittest.cc
@@ -4,11 +4,11 @@
 
 #include <packager/media/formats/webm/webm_content_encodings_client.h>
 
-#include <gtest/gtest.h>
-
 #include <string>
 
 #include <absl/strings/numbers.h>
+#include <gtest/gtest.h>
+
 #include <packager/media/formats/webm/webm_constants.h>
 #include <packager/media/formats/webm/webm_parser.h>
 

--- a/packager/media/formats/webm/webm_crypto_helpers.cc
+++ b/packager/media/formats/webm/webm_crypto_helpers.cc
@@ -6,6 +6,7 @@
 
 #include <absl/base/internal/endian.h>
 #include <glog/logging.h>
+
 #include <packager/media/base/buffer_reader.h>
 #include <packager/media/formats/webm/webm_constants.h>
 

--- a/packager/media/formats/webm/webm_crypto_helpers.h
+++ b/packager/media/formats/webm/webm_crypto_helpers.h
@@ -5,9 +5,10 @@
 #ifndef PACKAGER_MEDIA_FORMATS_WEBM_WEBM_CRYPTO_HELPERS_H_
 #define PACKAGER_MEDIA_FORMATS_WEBM_WEBM_CRYPTO_HELPERS_H_
 
-#include <packager/media/base/decrypt_config.h>
-#include <stdint.h>
+#include <cstdint>
 #include <memory>
+
+#include <packager/media/base/decrypt_config.h>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/webm/webm_info_parser.cc
+++ b/packager/media/formats/webm/webm_info_parser.cc
@@ -7,6 +7,7 @@
 #include <ctime>
 
 #include <glog/logging.h>
+
 #include <packager/media/formats/webm/webm_constants.h>
 
 namespace shaka {

--- a/packager/media/formats/webm/webm_media_parser.cc
+++ b/packager/media/formats/webm/webm_media_parser.cc
@@ -7,6 +7,7 @@
 #include <string>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/buffer_writer.h>
 #include <packager/media/base/timestamp.h>
 #include <packager/media/formats/webm/webm_cluster_parser.h>

--- a/packager/media/formats/webm/webm_parser.cc
+++ b/packager/media/formats/webm/webm_parser.cc
@@ -2,18 +2,20 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <packager/media/formats/webm/webm_parser.h>
-
 // This file contains code to parse WebM file elements. It was created
 // from information in the Matroska spec.
 // http://www.matroska.org/technical/specs/index.html
+//
 // This file contains code for encrypted WebM. Current WebM
 // encrypted request for comments specification is here
 // http://wiki.webmproject.org/encryption/webm-encryption-rfc
 
+#include <packager/media/formats/webm/webm_parser.h>
+
 #include <limits>
 
 #include <glog/logging.h>
+
 #include <packager/media/formats/webm/webm_constants.h>
 
 namespace shaka {

--- a/packager/media/formats/webm/webm_parser.h
+++ b/packager/media/formats/webm/webm_parser.h
@@ -5,8 +5,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_WEBM_WEBM_PARSER_H_
 #define PACKAGER_MEDIA_FORMATS_WEBM_WEBM_PARSER_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/packager/media/formats/webm/webm_tracks_parser.cc
+++ b/packager/media/formats/webm/webm_tracks_parser.cc
@@ -6,6 +6,7 @@
 
 #include <absl/strings/str_format.h>
 #include <glog/logging.h>
+
 #include <packager/media/base/timestamp.h>
 #include <packager/media/formats/webm/webm_constants.h>
 #include <packager/media/formats/webm/webm_content_encodings.h>

--- a/packager/media/formats/webm/webm_tracks_parser_unittest.cc
+++ b/packager/media/formats/webm/webm_tracks_parser_unittest.cc
@@ -4,10 +4,10 @@
 
 #include <packager/media/formats/webm/webm_tracks_parser.h>
 
+#include <glog/logging.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <glog/logging.h>
 #include <packager/media/base/timestamp.h>
 #include <packager/media/formats/webm/tracks_builder.h>
 #include <packager/media/formats/webm/webm_constants.h>

--- a/packager/media/formats/webm/webm_video_client.cc
+++ b/packager/media/formats/webm/webm_video_client.cc
@@ -5,6 +5,7 @@
 #include <packager/media/formats/webm/webm_video_client.h>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/video_util.h>
 #include <packager/media/codecs/av1_codec_configuration_record.h>
 #include <packager/media/codecs/vp_codec_configuration_record.h>

--- a/packager/media/formats/webm/webm_webvtt_parser.h
+++ b/packager/media/formats/webm/webm_webvtt_parser.h
@@ -5,8 +5,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_WEBM_WEBM_WEBVTT_PARSER_H_
 #define PACKAGER_MEDIA_FORMATS_WEBM_WEBM_WEBVTT_PARSER_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <string>
 
 #include <packager/macros.h>

--- a/packager/media/formats/webvtt/text_readers_unittest.cc
+++ b/packager/media/formats/webvtt/text_readers_unittest.cc
@@ -4,11 +4,12 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+#include <packager/media/formats/webvtt/text_readers.h>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <packager/file/file.h>
-#include <packager/media/formats/webvtt/text_readers.h>
 #include <packager/status/status_test_util.h>
 
 namespace shaka {

--- a/packager/media/formats/webvtt/webvtt_file_buffer.cc
+++ b/packager/media/formats/webvtt/webvtt_file_buffer.cc
@@ -7,6 +7,7 @@
 #include <packager/media/formats/webvtt/webvtt_file_buffer.h>
 
 #include <absl/strings/str_format.h>
+
 #include <packager/media/base/text_sample.h>
 #include <packager/media/formats/webvtt/webvtt_utils.h>
 

--- a/packager/media/formats/webvtt/webvtt_muxer_unittest.cc
+++ b/packager/media/formats/webvtt/webvtt_muxer_unittest.cc
@@ -4,6 +4,8 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+#include <packager/media/formats/webvtt/webvtt_muxer.h>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -12,7 +14,6 @@
 #include <packager/media/base/text_stream_info.h>
 #include <packager/media/event/combined_muxer_listener.h>
 #include <packager/media/event/mock_muxer_listener.h>
-#include <packager/media/formats/webvtt/webvtt_muxer.h>
 #include <packager/status/status_test_util.h>
 
 namespace shaka {

--- a/packager/media/formats/webvtt/webvtt_parser.cc
+++ b/packager/media/formats/webvtt/webvtt_parser.cc
@@ -10,6 +10,7 @@
 #include <absl/strings/str_format.h>
 #include <absl/strings/str_split.h>
 #include <glog/logging.h>
+
 #include <packager/kv_pairs/kv_pairs.h>
 #include <packager/media/base/text_stream_info.h>
 #include <packager/media/formats/webvtt/webvtt_utils.h>

--- a/packager/media/formats/webvtt/webvtt_parser_unittest.cc
+++ b/packager/media/formats/webvtt/webvtt_parser_unittest.cc
@@ -6,11 +6,12 @@
 
 #include <packager/media/formats/webvtt/webvtt_parser.h>
 
+#include <functional>
+
 #include <gtest/gtest.h>
 
 #include <packager/media/base/stream_info.h>
 #include <packager/media/base/text_sample.h>
-#include <functional>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/webvtt/webvtt_to_mp4_handler.h
+++ b/packager/media/formats/webvtt/webvtt_to_mp4_handler.h
@@ -7,8 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_WEBVTT_WEBVTT_MP4_CUE_HANDLER_H_
 #define PACKAGER_MEDIA_FORMATS_WEBVTT_WEBVTT_MP4_CUE_HANDLER_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <list>
 #include <queue>
 

--- a/packager/media/formats/webvtt/webvtt_to_mp4_handler_unittest.cc
+++ b/packager/media/formats/webvtt/webvtt_to_mp4_handler_unittest.cc
@@ -4,11 +4,12 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+#include <packager/media/formats/webvtt/webvtt_to_mp4_handler.h>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <packager/media/base/media_handler_test_base.h>
-#include <packager/media/formats/webvtt/webvtt_to_mp4_handler.h>
 #include <packager/status/status_test_util.h>
 
 using testing::_;

--- a/packager/media/formats/webvtt/webvtt_utils.cc
+++ b/packager/media/formats/webvtt/webvtt_utils.cc
@@ -6,10 +6,9 @@
 
 #include <packager/media/formats/webvtt/webvtt_utils.h>
 
-#include <ctype.h>
-#include <inttypes.h>
-
 #include <algorithm>
+#include <cctype>
+#include <cinttypes>
 #include <unordered_set>
 
 #include <absl/strings/numbers.h>

--- a/packager/media/formats/webvtt/webvtt_utils.h
+++ b/packager/media/formats/webvtt/webvtt_utils.h
@@ -7,15 +7,14 @@
 #ifndef PACKAGER_MEDIA_FORMATS_WEBVTT_UTILS_H_
 #define PACKAGER_MEDIA_FORMATS_WEBVTT_UTILS_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <list>
 #include <memory>
 #include <string>
+#include <string_view>
 
 #include <packager/media/base/text_sample.h>
 #include <packager/media/base/text_stream_info.h>
-#include <string_view>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/webvtt/webvtt_utils_unittest.cc
+++ b/packager/media/formats/webvtt/webvtt_utils_unittest.cc
@@ -4,9 +4,9 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <gtest/gtest.h>
-
 #include <packager/media/formats/webvtt/webvtt_utils.h>
+
+#include <gtest/gtest.h>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/wvm/wvm_media_parser.cc
+++ b/packager/media/formats/wvm/wvm_media_parser.cc
@@ -10,6 +10,7 @@
 
 #include <absl/base/internal/endian.h>
 #include <absl/strings/str_format.h>
+
 #include <packager/media/base/aes_decryptor.h>
 #include <packager/media/base/audio_stream_info.h>
 #include <packager/media/base/key_source.h>

--- a/packager/media/formats/wvm/wvm_media_parser.h
+++ b/packager/media/formats/wvm/wvm_media_parser.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include <absl/base/internal/endian.h>
+
 #include <packager/macros.h>
 #include <packager/media/base/media_parser.h>
 #include <packager/media/codecs/h264_byte_to_unit_stream_converter.h>

--- a/packager/media/formats/wvm/wvm_media_parser_unittest.cc
+++ b/packager/media/formats/wvm/wvm_media_parser_unittest.cc
@@ -2,13 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
+#include <packager/media/formats/wvm/wvm_media_parser.h>
 
 #include <algorithm>
+#include <functional>
 #include <string>
 
 #include <glog/logging.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
 #include <packager/media/base/audio_stream_info.h>
 #include <packager/media/base/media_sample.h>
 #include <packager/media/base/raw_key_source.h>
@@ -16,9 +19,7 @@
 #include <packager/media/base/stream_info.h>
 #include <packager/media/base/timestamp.h>
 #include <packager/media/base/video_stream_info.h>
-#include <packager/media/formats/wvm/wvm_media_parser.h>
 #include <packager/media/test/test_data_util.h>
-#include <functional>
 
 namespace {
 const char kWvmFile[] = "bear-640x360.wvm";

--- a/packager/media/replicator/replicator.cc
+++ b/packager/media/replicator/replicator.cc
@@ -4,9 +4,9 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <glog/logging.h>
-
 #include <packager/media/replicator/replicator.h>
+
+#include <glog/logging.h>
 
 namespace shaka {
 namespace media {

--- a/packager/media/test/test_data_util.h
+++ b/packager/media/test/test_data_util.h
@@ -5,8 +5,7 @@
 #ifndef PACKAGER_MEDIA_TEST_TEST_DATA_UTIL_H_
 #define PACKAGER_MEDIA_TEST_TEST_DATA_UTIL_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <filesystem>
 #include <string>
 #include <vector>

--- a/packager/media/trick_play/trick_play_handler.cc
+++ b/packager/media/trick_play/trick_play_handler.cc
@@ -7,6 +7,7 @@
 #include <packager/media/trick_play/trick_play_handler.h>
 
 #include <glog/logging.h>
+
 #include <packager/media/base/video_stream_info.h>
 #include <packager/status/status.h>
 

--- a/packager/mpd/base/adaptation_set.cc
+++ b/packager/mpd/base/adaptation_set.cc
@@ -6,11 +6,12 @@
 
 #include <packager/mpd/base/adaptation_set.h>
 
-#include <absl/strings/numbers.h>
-#include <glog/logging.h>
 #include <cmath>
 
+#include <absl/strings/numbers.h>
 #include <absl/strings/str_format.h>
+#include <glog/logging.h>
+
 #include <packager/mpd/base/media_info.pb.h>
 #include <packager/mpd/base/mpd_options.h>
 #include <packager/mpd/base/mpd_utils.h>

--- a/packager/mpd/base/adaptation_set.h
+++ b/packager/mpd/base/adaptation_set.h
@@ -9,8 +9,7 @@
 #ifndef PACKAGER_MPD_BASE_ADAPTATION_SET_H_
 #define PACKAGER_MPD_BASE_ADAPTATION_SET_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <list>
 #include <map>
 #include <memory>

--- a/packager/mpd/base/bandwidth_estimator.h
+++ b/packager/mpd/base/bandwidth_estimator.h
@@ -7,8 +7,7 @@
 #ifndef MPD_BASE_BANDWIDTH_ESTIMATOR_H_
 #define MPD_BASE_BANDWIDTH_ESTIMATOR_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <vector>
 
 namespace shaka {

--- a/packager/mpd/base/mock_mpd_builder.cc
+++ b/packager/mpd/base/mock_mpd_builder.cc
@@ -1,3 +1,9 @@
+// Copyright 2023 Google LLC. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
 #include <packager/mpd/base/mock_mpd_builder.h>
 
 #include <packager/mpd/base/media_info.pb.h>

--- a/packager/mpd/base/mock_mpd_builder.h
+++ b/packager/mpd/base/mock_mpd_builder.h
@@ -7,9 +7,9 @@
 #ifndef MPD_BASE_MOCK_MPD_BUILDER_H_
 #define MPD_BASE_MOCK_MPD_BUILDER_H_
 
+#include <absl/synchronization/mutex.h>
 #include <gmock/gmock.h>
 
-#include <absl/synchronization/mutex.h>
 #include <packager/macros.h>
 #include <packager/mpd/base/adaptation_set.h>
 #include <packager/mpd/base/content_protection_element.h>

--- a/packager/mpd/base/mock_mpd_notifier.cc
+++ b/packager/mpd/base/mock_mpd_notifier.cc
@@ -1,3 +1,9 @@
+// Copyright 2023 Google LLC. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
 #include <packager/mpd/base/mock_mpd_notifier.h>
 
 namespace shaka {

--- a/packager/mpd/base/mock_mpd_notifier.h
+++ b/packager/mpd/base/mock_mpd_notifier.h
@@ -7,12 +7,11 @@
 #ifndef MPD_BASE_MOCK_MPD_NOTIFIER_H_
 #define MPD_BASE_MOCK_MPD_NOTIFIER_H_
 
-#include <packager/mpd/base/mpd_notifier.h>
-
 #include <gmock/gmock.h>
 
 #include <packager/mpd/base/content_protection_element.h>
 #include <packager/mpd/base/media_info.pb.h>
+#include <packager/mpd/base/mpd_notifier.h>
 
 namespace shaka {
 

--- a/packager/mpd/base/mpd_builder.cc
+++ b/packager/mpd/base/mpd_builder.cc
@@ -6,14 +6,15 @@
 
 #include <packager/mpd/base/mpd_builder.h>
 
-#include <absl/strings/numbers.h>
-#include <absl/strings/str_format.h>
-#include <absl/synchronization/mutex.h>
-#include <glog/logging.h>
 #include <algorithm>
 #include <chrono>
 #include <filesystem>
 #include <optional>
+
+#include <absl/strings/numbers.h>
+#include <absl/strings/str_format.h>
+#include <absl/synchronization/mutex.h>
+#include <glog/logging.h>
 
 #include <packager/file/file_util.h>
 #include <packager/media/base/rcheck.h>

--- a/packager/mpd/base/mpd_builder.h
+++ b/packager/mpd/base/mpd_builder.h
@@ -11,13 +11,13 @@
 #ifndef MPD_BASE_MPD_BUILDER_H_
 #define MPD_BASE_MPD_BUILDER_H_
 
-#include <libxml/tree.h>
-
 #include <chrono>
 #include <list>
 #include <memory>
 #include <optional>
 #include <string>
+
+#include <libxml/tree.h>
 
 #include <packager/macros.h>
 #include <packager/mpd/base/mpd_options.h>

--- a/packager/mpd/base/mpd_builder_unittest.cc
+++ b/packager/mpd/base/mpd_builder_unittest.cc
@@ -4,13 +4,14 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
+#include <packager/mpd/base/mpd_builder.h>
 
 #include <memory>
 
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
 #include <packager/mpd/base/adaptation_set.h>
-#include <packager/mpd/base/mpd_builder.h>
 #include <packager/mpd/base/period.h>
 #include <packager/mpd/base/representation.h>
 #include <packager/mpd/test/mpd_builder_test_helper.h>

--- a/packager/mpd/base/mpd_notifier.h
+++ b/packager/mpd/base/mpd_notifier.h
@@ -10,8 +10,7 @@
 #ifndef MPD_BASE_MPD_NOTIFIER_H_
 #define MPD_BASE_MPD_NOTIFIER_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/packager/mpd/base/mpd_notifier_util.cc
+++ b/packager/mpd/base/mpd_notifier_util.cc
@@ -7,6 +7,7 @@
 #include <packager/mpd/base/mpd_notifier_util.h>
 
 #include <glog/logging.h>
+
 #include <packager/file/file.h>
 #include <packager/mpd/base/mpd_utils.h>
 

--- a/packager/mpd/base/mpd_notifier_util.h
+++ b/packager/mpd/base/mpd_notifier_util.h
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include <absl/strings/escaping.h>
+
 #include <packager/mpd/base/media_info.pb.h>
 #include <packager/mpd/base/mpd_builder.h>
 

--- a/packager/mpd/base/mpd_utils.cc
+++ b/packager/mpd/base/mpd_utils.cc
@@ -9,10 +9,10 @@
 #include <absl/flags/flag.h>
 #include <absl/strings/escaping.h>
 #include <absl/strings/numbers.h>
+#include <absl/strings/str_format.h>
 #include <glog/logging.h>
 #include <libxml/tree.h>
 
-#include <absl/strings/str_format.h>
 #include <packager/media/base/language_utils.h>
 #include <packager/media/base/protection_system_specific_info.h>
 #include <packager/mpd/base/adaptation_set.h>

--- a/packager/mpd/base/mpd_utils.h
+++ b/packager/mpd/base/mpd_utils.h
@@ -9,11 +9,11 @@
 #ifndef MPD_BASE_MPD_UTILS_H_
 #define MPD_BASE_MPD_UTILS_H_
 
-#include <libxml/tree.h>
-
 #include <cstdint>
 #include <list>
 #include <string>
+
+#include <libxml/tree.h>
 
 namespace shaka {
 

--- a/packager/mpd/base/mpd_utils_unittest.cc
+++ b/packager/mpd/base/mpd_utils_unittest.cc
@@ -4,14 +4,16 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <absl/strings/escaping.h>
-#include <gtest/gtest.h>
+#include <packager/mpd/base/mpd_utils.h>
+
 #include <memory>
 
+#include <absl/strings/escaping.h>
 #include <absl/types/span.h>
+#include <gtest/gtest.h>
+
 #include <packager/mpd/base/adaptation_set.h>
 #include <packager/mpd/base/mpd_options.h>
-#include <packager/mpd/base/mpd_utils.h>
 #include <packager/mpd/test/mpd_builder_test_helper.h>
 #include <packager/mpd/test/xml_compare.h>
 

--- a/packager/mpd/base/period.cc
+++ b/packager/mpd/base/period.cc
@@ -4,8 +4,9 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <glog/logging.h>
 #include <packager/mpd/base/period.h>
+
+#include <glog/logging.h>
 
 #include <packager/mpd/base/adaptation_set.h>
 #include <packager/mpd/base/mpd_options.h>

--- a/packager/mpd/base/period.h
+++ b/packager/mpd/base/period.h
@@ -11,11 +11,11 @@
 
 #include <list>
 #include <map>
+#include <optional>
 
 #include <packager/mpd/base/adaptation_set.h>
 #include <packager/mpd/base/media_info.pb.h>
 #include <packager/mpd/base/xml/xml_node.h>
-#include <optional>
 
 namespace shaka {
 

--- a/packager/mpd/base/representation.cc
+++ b/packager/mpd/base/representation.cc
@@ -6,10 +6,11 @@
 
 #include <packager/mpd/base/representation.h>
 
+#include <algorithm>
+
 #include <absl/flags/declare.h>
 #include <absl/strings/str_format.h>
 #include <glog/logging.h>
-#include <algorithm>
 
 #include <packager/file/file.h>
 #include <packager/media/base/muxer_util.h>

--- a/packager/mpd/base/representation.h
+++ b/packager/mpd/base/representation.h
@@ -9,8 +9,7 @@
 #ifndef PACKAGER_MPD_BASE_REPRESENTATION_H_
 #define PACKAGER_MPD_BASE_REPRESENTATION_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <list>
 #include <memory>
 #include <optional>

--- a/packager/mpd/base/representation_unittest.cc
+++ b/packager/mpd/base/representation_unittest.cc
@@ -6,12 +6,13 @@
 
 #include <packager/mpd/base/representation.h>
 
+#include <cinttypes>
+
 #include <absl/flags/declare.h>
 #include <absl/flags/flag.h>
 #include <absl/strings/str_format.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <inttypes.h>
 
 #include <packager/file/file.h>
 #include <packager/file/file_closer.h>

--- a/packager/mpd/base/segment_info.h
+++ b/packager/mpd/base/segment_info.h
@@ -7,7 +7,10 @@
 #ifndef MPD_BASE_SEGMENT_INFO_H_
 #define MPD_BASE_SEGMENT_INFO_H_
 
+#include <cstdint>
+
 namespace shaka {
+
 /// Container for keeping track of information about a segment.
 /// Used for keeping track of all the segments used for generating MPD with
 /// dynamic  profile.
@@ -21,6 +24,7 @@ struct SegmentInfo {
   // in the DASH MPD spec.
   int repeat;
 };
+
 }  // namespace shaka
 
 #endif  // MPD_BASE_SEGMENT_INFO_H_

--- a/packager/mpd/base/simple_mpd_notifier.cc
+++ b/packager/mpd/base/simple_mpd_notifier.cc
@@ -7,6 +7,7 @@
 #include <packager/mpd/base/simple_mpd_notifier.h>
 
 #include <glog/logging.h>
+
 #include <packager/mpd/base/adaptation_set.h>
 #include <packager/mpd/base/mpd_builder.h>
 #include <packager/mpd/base/mpd_notifier_util.h>

--- a/packager/mpd/base/simple_mpd_notifier.h
+++ b/packager/mpd/base/simple_mpd_notifier.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include <absl/synchronization/mutex.h>
+
 #include <packager/mpd/base/mpd_notifier.h>
 #include <packager/mpd/base/mpd_notifier_util.h>
 

--- a/packager/mpd/base/simple_mpd_notifier_unittest.cc
+++ b/packager/mpd/base/simple_mpd_notifier_unittest.cc
@@ -4,16 +4,18 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+#include <packager/mpd/base/simple_mpd_notifier.h>
+
+#include <filesystem>
+
 #include <gmock/gmock.h>
 #include <google/protobuf/util/message_differencer.h>
 #include <gtest/gtest.h>
-#include <filesystem>
 
 #include <packager/file/file_test_util.h>
 #include <packager/mpd/base/mock_mpd_builder.h>
 #include <packager/mpd/base/mpd_builder.h>
 #include <packager/mpd/base/mpd_options.h>
-#include <packager/mpd/base/simple_mpd_notifier.h>
 #include <packager/mpd/test/mpd_builder_test_helper.h>
 
 namespace shaka {

--- a/packager/mpd/base/xml/scoped_xml_ptr.h
+++ b/packager/mpd/base/xml/scoped_xml_ptr.h
@@ -10,10 +10,10 @@
 #ifndef MPD_BASE_XML_SCOPED_XML_PTR_H_
 #define MPD_BASE_XML_SCOPED_XML_PTR_H_
 
+#include <memory>
+
 #include <libxml/tree.h>
 #include <libxml/xmlschemas.h>
-
-#include <memory>
 
 namespace shaka {
 namespace xml {

--- a/packager/mpd/base/xml/xml_node.cc
+++ b/packager/mpd/base/xml/xml_node.cc
@@ -6,18 +6,18 @@
 
 #include <packager/mpd/base/xml/xml_node.h>
 
-#include <absl/base/internal/endian.h>
-#include <absl/flags/flag.h>
-#include <absl/strings/numbers.h>
-#include <glog/logging.h>
-#include <libxml/tree.h>
-
 #include <cmath>
 #include <limits>
 #include <set>
 
+#include <absl/base/internal/endian.h>
+#include <absl/flags/flag.h>
 #include <absl/strings/escaping.h>
+#include <absl/strings/numbers.h>
 #include <absl/strings/str_format.h>
+#include <glog/logging.h>
+#include <libxml/tree.h>
+
 #include <packager/macros.h>
 #include <packager/media/base/rcheck.h>
 #include <packager/mpd/base/media_info.pb.h>

--- a/packager/mpd/base/xml/xml_node.h
+++ b/packager/mpd/base/xml/xml_node.h
@@ -10,8 +10,7 @@
 #ifndef MPD_BASE_XML_XML_NODE_H_
 #define MPD_BASE_XML_XML_NODE_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <list>
 #include <set>
 #include <string>

--- a/packager/mpd/base/xml/xml_node_unittest.cc
+++ b/packager/mpd/base/xml/xml_node_unittest.cc
@@ -4,18 +4,19 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+#include <packager/mpd/base/xml/xml_node.h>
+
+#include <list>
+
 #include <absl/flags/declare.h>
 #include <absl/flags/flag.h>
+#include <glog/logging.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <libxml/tree.h>
 
-#include <list>
-
-#include <glog/logging.h>
 #include <packager/flag_saver.h>
 #include <packager/mpd/base/segment_info.h>
-#include <packager/mpd/base/xml/xml_node.h>
 #include <packager/mpd/test/mpd_builder_test_helper.h>
 #include <packager/mpd/test/xml_compare.h>
 

--- a/packager/mpd/test/mpd_builder_test_helper.cc
+++ b/packager/mpd/test/mpd_builder_test_helper.cc
@@ -6,10 +6,11 @@
 
 #include <packager/mpd/test/mpd_builder_test_helper.h>
 
+#include <filesystem>
+
 #include <glog/logging.h>
 #include <google/protobuf/text_format.h>
 #include <gtest/gtest.h>
-#include <filesystem>
 
 #include <packager/media/test/test_data_util.h>
 #include <packager/mpd/base/media_info.pb.h>

--- a/packager/mpd/test/xml_compare.cc
+++ b/packager/mpd/test/xml_compare.cc
@@ -1,13 +1,20 @@
+// Copyright 2023 Google LLC. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
 #include <packager/mpd/test/xml_compare.h>
+
+#include <algorithm>
+#include <map>
+#include <string>
+#include <utility>
 
 #include <absl/strings/strip.h>
 #include <glog/logging.h>
 #include <libxml/parser.h>
 #include <libxml/tree.h>
-#include <algorithm>
-#include <map>
-#include <string>
-#include <utility>
 
 namespace shaka {
 

--- a/packager/mpd/test/xml_compare.h
+++ b/packager/mpd/test/xml_compare.h
@@ -1,14 +1,20 @@
+// Copyright 2023 Google LLC. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
 #ifndef MPD_TEST_XML_COMPARE_H_
 #define MPD_TEST_XML_COMPARE_H_
+
+#include <optional>
+#include <string>
 
 #include <gmock/gmock.h>
 #include <libxml/tree.h>
 
-#include <string>
-
 #include <packager/mpd/base/xml/scoped_xml_ptr.h>
 #include <packager/mpd/base/xml/xml_node.h>
-#include <optional>
 
 namespace shaka {
 

--- a/packager/mpd/util/mpd_writer.cc
+++ b/packager/mpd/util/mpd_writer.cc
@@ -6,10 +6,11 @@
 
 #include <packager/mpd/util/mpd_writer.h>
 
+#include <cstdint>
+
 #include <absl/flags/flag.h>
 #include <glog/logging.h>
 #include <google/protobuf/text_format.h>
-#include <stdint.h>
 
 #include <packager/file/file.h>
 #include <packager/mpd/base/mpd_builder.h>

--- a/packager/mpd/util/mpd_writer_unittest.cc
+++ b/packager/mpd/util/mpd_writer_unittest.cc
@@ -4,15 +4,17 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+#include <packager/mpd/util/mpd_writer.h>
+
+#include <filesystem>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <filesystem>
 
 #include <packager/file/file_test_util.h>
 #include <packager/mpd/base/mock_mpd_notifier.h>
 #include <packager/mpd/base/mpd_options.h>
 #include <packager/mpd/test/mpd_builder_test_helper.h>
-#include <packager/mpd/util/mpd_writer.h>
 
 namespace shaka {
 

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -7,10 +7,13 @@
 #include <packager/packager.h>
 
 #include <algorithm>
+#include <chrono>
+#include <optional>
 
 #include <absl/strings/match.h>
 #include <absl/strings/str_format.h>
 #include <glog/logging.h>
+
 #include <packager/app/job_manager.h>
 #include <packager/app/muxer_factory.h>
 #include <packager/app/packager_util.h>
@@ -38,8 +41,6 @@
 #include <packager/mpd/base/simple_mpd_notifier.h>
 #include <packager/status/status_macros.h>
 #include <packager/version/version.h>
-#include <chrono>
-#include <optional>
 
 namespace shaka {
 

--- a/packager/status/status.cc
+++ b/packager/status/status.cc
@@ -8,6 +8,7 @@
 
 #include <absl/strings/str_format.h>
 #include <glog/logging.h>
+
 #include <packager/macros.h>
 
 namespace shaka {

--- a/packager/status/status_test_util_unittest.cc
+++ b/packager/status/status_test_util_unittest.cc
@@ -4,9 +4,9 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <gtest/gtest-spi.h>
-
 #include <packager/status/status_test_util.h>
+
+#include <gtest/gtest.h>
 
 namespace shaka {
 namespace media {

--- a/packager/status/status_test_util_unittest.cc
+++ b/packager/status/status_test_util_unittest.cc
@@ -6,7 +6,7 @@
 
 #include <packager/status/status_test_util.h>
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-spi.h>
 
 namespace shaka {
 namespace media {

--- a/packager/status/status_unittest.cc
+++ b/packager/status/status_unittest.cc
@@ -4,11 +4,11 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
+#include <packager/status/status.h>
 
 #include <absl/strings/str_format.h>
-#include <packager/status/status.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 namespace shaka {
 

--- a/packager/utils/absl_flag_hexbytes.cc
+++ b/packager/utils/absl_flag_hexbytes.cc
@@ -5,7 +5,9 @@
 // https://developers.google.com/open-source/licenses/bsd
 
 #include <packager/utils/absl_flag_hexbytes.h>
-#include <packager/utils/hex_parser.h>
+
+#include <iostream>
+#include <vector>
 
 #include <absl/flags/flag.h>
 #include <absl/flags/parse.h>
@@ -15,8 +17,8 @@
 #include <absl/strings/str_format.h>
 #include <absl/strings/str_join.h>
 #include <absl/strings/str_split.h>
-#include <iostream>
-#include <vector>
+
+#include <packager/utils/hex_parser.h>
 
 namespace shaka {
 

--- a/packager/utils/absl_flag_hexbytes.h
+++ b/packager/utils/absl_flag_hexbytes.h
@@ -7,11 +7,11 @@
 #ifndef SHAKA_PACKAGER_ABSL_FLAG_HEXBYTES_H
 #define SHAKA_PACKAGER_ABSL_FLAG_HEXBYTES_H
 
-#include <packager/utils/hex_parser.h>
-
 #include <absl/flags/flag.h>
 #include <absl/strings/ascii.h>
 #include <absl/strings/escaping.h>
+
+#include <packager/utils/hex_parser.h>
 
 // Custom flag type for hexadecimal byte array
 namespace shaka {

--- a/packager/utils/clock.cc
+++ b/packager/utils/clock.cc
@@ -1,3 +1,9 @@
+// Copyright 2023 Google LLC. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
 #include <packager/utils/clock.h>
 
 namespace shaka {

--- a/packager/utils/test_clock.cc
+++ b/packager/utils/test_clock.cc
@@ -1,16 +1,17 @@
-//  Copyright 2023 Google LLC. All rights reserved.
+// Copyright 2023 Google LLC. All rights reserved.
 //
-//  Use of this source code is governed by a BSD-style
-//  license that can be found in the LICENSE file or at
-//  https://developers.google.com/open-source/licenses/bsd
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
 
 #include <packager/utils/test_clock.h>
 
-#include <absl/strings/str_split.h>
-#include <absl/strings/string_view.h>
 #include <ctime>
 #include <iostream>
 #include <string>
+
+#include <absl/strings/str_split.h>
+#include <absl/strings/string_view.h>
 
 std::tm parseISO8601(const std::string& date_string) {
   std::tm tm = {};

--- a/packager/utils/test_clock.h
+++ b/packager/utils/test_clock.h
@@ -7,9 +7,10 @@
 #ifndef SHAKA_PACKAGER_TEST_CLOCK_H
 #define SHAKA_PACKAGER_TEST_CLOCK_H
 
-#include <packager/utils/clock.h>
 #include <chrono>
 #include <string>
+
+#include <packager/utils/clock.h>
 
 namespace shaka {
 

--- a/packager/version/version.h
+++ b/packager/version/version.h
@@ -4,6 +4,9 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+#ifndef PACKAGER_VERSION_VERSION_H_
+#define PACKAGER_VERSION_VERSION_H_
+
 #include <string>
 
 namespace shaka {
@@ -19,3 +22,5 @@ std::string GetPackagerVersion();
 void SetPackagerVersionForTesting(const std::string& version);
 
 }  // namespace shaka
+
+#endif  // PACKAGER_VERSION_VERSION_H_


### PR DESCRIPTION
Reorder headers to follow the Google C++ Style Guide:

> In dir/foo.cc or dir/foo_test.cc:
>
> 1. dir2/foo2.h.
> 2. A blank line
> 3. C system headers (more precisely: headers in angle brackets with the .h extension), e.g., <unistd.h>, <stdlib.h>.
> 4. A blank line
> 5. C++ standard library headers (without file extension), e.g., <algorithm>, <cstddef>.
> 6. A blank line
> 7. Other libraries' .h files.
> 8. A blank line
> 9. Your project's .h files.

https://google.github.io/styleguide/cppguide.html#Names_and_Order_of_Includes