### PR TITLE
build: Fix rebuild of link-test targets

### DIFF
--- a/link-test/CMakeLists.txt
+++ b/link-test/CMakeLists.txt
@@ -11,16 +11,30 @@ if(LIBPACKAGER_SHARED)
   # Install the library and headers to a temporary location.
   set(TEST_INSTALL_DIR ${CMAKE_BINARY_DIR}/test-install)
 
-  add_custom_target(test-install ALL
+  # Custom commands aren't targets, but have outputs.
+  add_custom_command(
     DEPENDS mpd_generator packager libpackager
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    OUTPUT ${TEST_INSTALL_DIR}
     COMMAND
       ${CMAKE_COMMAND} --install . --prefix ${TEST_INSTALL_DIR} --config "$<CONFIG>")
+
+  # Custom targets with commands run every time, no matter what.  A custom
+  # target with no command, but which depends on a custom command's output,
+  # gets us something that acts like a real target and doesn't re-run every
+  # time.
+  add_custom_target(test-install ALL DEPENDS ${TEST_INSTALL_DIR})
 
   # Then try to build a very simplistic test app to prove that we can include
   # the headers and link the library.
   add_executable(packager_link_test test.cc)
+
+  # Both of these are needed.  The first is a basic dependency to make sure
+  # test-install runs first, whereas the second treats test.cc as dirty if
+  # test-install runs again.
   add_dependencies(packager_link_test test-install)
+  set_source_files_properties(test.cc PROPERTIES OBJECT_DEPENDS ${TEST_INSTALL_DIR})
+
   target_link_directories(packager_link_test PRIVATE ${TEST_INSTALL_DIR}/lib)
   target_include_directories(packager_link_test PRIVATE ${TEST_INSTALL_DIR}/include)
   if(NOT MSVC)


### PR DESCRIPTION
The link-test targets rebuilt every time you built the project because that is the behavior of commands attached to add_custom_target.  This is fixed by combining add_custom_command and add_custom_target.

Fixing that led to a situation where the link-test targets built on the first build, but didn't properly rebuild when their dependencies changed.  This is fixed by using set_source_file_properties to treat test.cc as dirty when the test-install command runs.