### PR TITLE
build: Fix pssh-box.py targets, installation, and docs

### DIFF
--- a/packager/CMakeLists.txt
+++ b/packager/CMakeLists.txt
@@ -194,10 +194,15 @@ target_link_libraries(packager_test
 configure_file(packager.pc.in packager.pc @ONLY)
 
 
-install(TARGETS mpd_generator packager libpackager
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(DIRECTORY ../include/packager
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-install(FILES tools/pssh/pssh-box.py DESTINATION ${CMAKE_INSTALL_BINDIR})
-install(FILES ${CMAKE_BINARY_DIR}/packager/packager.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+install(TARGETS mpd_generator packager libpackager)
+
+install(PROGRAMS ${CMAKE_BINARY_DIR}/pssh-box.py
+  DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(DIRECTORY ${CMAKE_BINARY_DIR}/pssh-box-protos
+  DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+install(FILES ${CMAKE_BINARY_DIR}/packager/packager.pc
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/packager/protobuf.cmake
+++ b/packager/protobuf.cmake
@@ -7,7 +7,8 @@
 # Define a custom function to create protobuf libraries.  This is similar to
 # the one defined in the CMake FindProtobuf.cmake module, but allows us to more
 # easily hook into the protobuf submodule to do the work instead of searching
-# for a system-wide installation.
+# for a system-wide installation.  Generates both C++ library targets and
+# Python proto modules.
 
 function(add_proto_library NAME)
   cmake_parse_arguments(PARSE_ARGV
@@ -51,9 +52,13 @@ function(add_proto_library NAME)
     add_custom_command(
       OUTPUT ${_generated_cpp} ${_generated_h}
       COMMAND protoc
-      ARGS -I${CMAKE_CURRENT_SOURCE_DIR}/${_dir} --cpp_out=${CMAKE_CURRENT_BINARY_DIR}/${_dir} ${CMAKE_CURRENT_SOURCE_DIR}/${_path}
+      ARGS
+        -I${CMAKE_CURRENT_SOURCE_DIR}/${_dir}
+        --cpp_out=${CMAKE_CURRENT_BINARY_DIR}/${_dir}
+        --python_out=${CMAKE_CURRENT_BINARY_DIR}/${_dir}
+        ${CMAKE_CURRENT_SOURCE_DIR}/${_path}
       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${_path} protoc
-      COMMENT "Running C++ protocol buffer compiler on ${_path}"
+      COMMENT "Running protocol buffer compiler on ${_path}"
       VERBATIM)
   endforeach()
 

--- a/packager/tools/CMakeLists.txt
+++ b/packager/tools/CMakeLists.txt
@@ -17,3 +17,5 @@ add_library(license_notice STATIC
 
 # Anyone who depends on this library will need this include directory.
 target_include_directories(license_notice PUBLIC "${CMAKE_BINARY_DIR}")
+
+add_subdirectory(pssh)

--- a/packager/tools/pssh/CMakeLists.txt
+++ b/packager/tools/pssh/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Copyright 2023 Google LLC. All rights reserved.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file or at
+# https://developers.google.com/open-source/licenses/bsd
+
+# Copy the pssh-box.py script and its protos into the required directory
+# structure.
+set(PSSH_BOX_OUTPUTS
+    ${CMAKE_BINARY_DIR}/pssh-box.py
+    ${CMAKE_BINARY_DIR}/pssh-box-protos
+    ${CMAKE_BINARY_DIR}/pssh-box-protos/widevine_common_encryption_pb2.py
+    ${CMAKE_BINARY_DIR}/pssh-box-protos/widevine_pssh_data_pb2.py)
+
+add_custom_command(
+    DEPENDS
+        widevine_protos
+        pssh-box.py
+    OUTPUT ${PSSH_BOX_OUTPUTS}
+    COMMAND
+        ${CMAKE_COMMAND} -E make_directory
+        ${CMAKE_BINARY_DIR}/pssh-box-protos/
+    COMMAND
+        ${CMAKE_COMMAND} -E copy
+        ${CMAKE_BINARY_DIR}/packager/media/base/widevine_common_encryption_pb2.py
+        ${CMAKE_BINARY_DIR}/packager/media/base/widevine_pssh_data_pb2.py
+        ${CMAKE_BINARY_DIR}/pssh-box-protos/
+    COMMAND
+        ${CMAKE_COMMAND} -E copy
+        ${CMAKE_CURRENT_SOURCE_DIR}/pssh-box.py
+        ${CMAKE_BINARY_DIR}/)
+
+add_custom_target(pssh_box_py ALL DEPENDS ${PSSH_BOX_OUTPUTS})

--- a/packager/tools/pssh/README.md
+++ b/packager/tools/pssh/README.md
@@ -3,7 +3,7 @@ pssh-box - Utility to parse and generate PSSH boxes
 
 ## Prerequisite
 
-- Python 2.6 or newer.
+- Python 3.
 
 ## Build the utility using Shaka Packager build setup
 
@@ -16,11 +16,10 @@ https://github.com/shaka-project/shaka-packager/blob/master/docs/source/build_in
 With the build environment set up, use `ninja` to build the utility:
 
 ```bash
-$ ninja -C out/Release pssh_box_py
+$ ninja -C build/ pssh-box.py
 ```
 
-Then you can use the built utility in `out/Release/pssh_box.py`. You can add
-`out/Release` to your `PATH` so you can run it from anywhere.
+Then you can use the built utility in `build/pssh-box.py`.
 
 ## Usage
 

--- a/packager/tools/pssh/pssh-box.py
+++ b/packager/tools/pssh/pssh-box.py
@@ -32,11 +32,12 @@ def to_code_point(value):
 
 
 _script_dir = os.path.dirname(os.path.realpath(__file__))
-_proto_path = os.path.join(_script_dir, 'pyproto')
+_proto_path = os.path.join(_script_dir, 'pssh-box-protos')
 _widevine_proto_path = os.path.join(_proto_path, 'packager/media/base')
 
 assert os.path.exists(_proto_path), (
-    'Please run from output directory, e.g. out/Debug/pssh-box.py')
+    'Failed to find proto, please run built/installed version. ' +
+    ' e.g. build/packager/pssh-box.py')
 
 sys.path.insert(0, _proto_path)
 sys.path.insert(0, _widevine_proto_path)


### PR DESCRIPTION
pssh-box.py needs Python protos, which we were not building.  It also needs to have those protos installed properly.

This fixes generation of Python proto interfaces and fixes the install targets to put those protos where they are needed.  This also updates the documentation to match.