### PR TITLE
fix: Fix internal libraries built as dynamic by default

### DIFF
--- a/packager/hls/CMakeLists.txt
+++ b/packager/hls/CMakeLists.txt
@@ -1,12 +1,10 @@
-
-# Copyright 2016 Google LLC. All rights reserved.
+# Copyright 2023 Google LLC. All rights reserved.
 #
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file or at
 # https://developers.google.com/open-source/licenses/bsd
 
-
-add_library(hls_builder
+add_library(hls_builder STATIC
   base/hls_notifier.h
   base/master_playlist.cc
   base/master_playlist.h

--- a/packager/utils/CMakeLists.txt
+++ b/packager/utils/CMakeLists.txt
@@ -29,7 +29,7 @@ target_link_libraries(hex_bytes_flags
   absl::strings
   absl::flags)
 
-add_library(string_utils
+add_library(string_utils STATIC
   string_trim_split.cc
 )
 target_link_libraries(string_utils


### PR DESCRIPTION
This caused issues with some shared library link tests when I tried to split the library target into shared and static targets.