### PR TITLE
feat: Build c-ares locally

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -110,7 +110,6 @@ jobs:
         run: |
           sudo apt update && sudo apt install -y \
               cmake \
-              libc-ares-dev \
               ninja-build
 
       - name: Install Mac deps

--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "packager/third_party/mongoose/source"]
 	path = packager/third_party/mongoose/source
 	url = https://github.com/cesanta/mongoose
+[submodule "packager/third_party/c-ares/source"]
+	path = packager/third_party/c-ares/source
+	url = https://github.com/c-ares/c-ares

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.12 as builder
 # Install utilities, libraries, and dev tools.
 RUN apk add --no-cache \
         bash curl \
-        bsd-compat-headers c-ares-dev linux-headers \
+        bsd-compat-headers linux-headers \
         build-base cmake git ninja python3
 
 # Build shaka-packager from the current directory, rather than what has been

--- a/docs/source/build_instructions.md
+++ b/docs/source/build_instructions.md
@@ -12,7 +12,6 @@ for [other distros below](#notes-for-other-linux-distros).
 sudo apt-get update
 sudo apt-get install -y \
         curl \
-        libc-ares-dev \
         build-essential cmake git ninja-build python3
 ```
 
@@ -153,7 +152,7 @@ Use `apk` command to install dependencies:
 ```shell
 apk add --no-cache \
         bash curl \
-        bsd-compat-headers c-ares-dev linux-headers \
+        bsd-compat-headers linux-headers \
         build-base cmake git ninja python3
 ```
 
@@ -164,7 +163,6 @@ Instead of running `sudo apt-get install` to install build dependencies, run:
 ```shell
 pacman -Suy --needed --noconfirm \
         core/which \
-        c-ares \
         cmake gcc git ninja python3
 ```
 
@@ -175,7 +173,6 @@ Same as Ubuntu.
 ```shell
 apt-get install -y \
         curl \
-        libc-ares-dev \
         build-essential cmake git ninja-build python3
 ```
 
@@ -186,7 +183,7 @@ Instead of running `sudo apt-get install` to install build dependencies, run:
 ```shell
 yum install -y \
         which \
-        c-ares-devel libatomic \
+        libatomic \
         cmake gcc-c++ git ninja-build python3
 ```
 
@@ -205,7 +202,7 @@ then same as Fedora
 ```shell
 yum install -y \
         which \
-        c-ares-devel libatomic \
+        libatomic \
         cmake gcc-c++ git ninja-build python3
 ```
 
@@ -216,7 +213,6 @@ Use `zypper` command to install dependencies:
 ```shell
 zypper in -y \
         curl which \
-        c-ares-devel \
         cmake gcc9-c++ git ninja python3
 ```
 

--- a/packager/testing/dockers/Alpine_Dockerfile
+++ b/packager/testing/dockers/Alpine_Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.12
 # Install utilities, libraries, and dev tools.
 RUN apk add --no-cache \
         bash curl \
-        bsd-compat-headers c-ares-dev linux-headers \
+        bsd-compat-headers linux-headers \
         build-base cmake git ninja python3
 
 # Build and run this docker by mapping shaka-packager with

--- a/packager/testing/dockers/ArchLinux_Dockerfile
+++ b/packager/testing/dockers/ArchLinux_Dockerfile
@@ -3,7 +3,6 @@ FROM archlinux:latest
 # Install utilities, libraries, and dev tools.
 RUN pacman -Suy --needed --noconfirm \
         core/which \
-        c-ares \
         cmake gcc git ninja python3
 
 # Build and run this docker by mapping shaka-packager with

--- a/packager/testing/dockers/CentOS_Dockerfile
+++ b/packager/testing/dockers/CentOS_Dockerfile
@@ -9,7 +9,7 @@ RUN dnf config-manager --set-enabled crb
 # Install utilities, libraries, and dev tools.
 RUN yum install -y \
         which \
-        c-ares-devel libatomic \
+        libatomic \
         cmake gcc-c++ git ninja-build python3
 
 # Build and run this docker by mapping shaka-packager with

--- a/packager/testing/dockers/Debian_Dockerfile
+++ b/packager/testing/dockers/Debian_Dockerfile
@@ -4,7 +4,6 @@ FROM debian:11
 RUN apt-get update && apt-get install -y apt-utils
 RUN apt-get install -y \
         curl \
-        libc-ares-dev \
         build-essential cmake git ninja-build python3
 
 # Build and run this docker by mapping shaka-packager with

--- a/packager/testing/dockers/Fedora_Dockerfile
+++ b/packager/testing/dockers/Fedora_Dockerfile
@@ -3,7 +3,7 @@ FROM fedora:34
 # Install utilities, libraries, and dev tools.
 RUN yum install -y \
         which \
-        c-ares-devel libatomic \
+        libatomic \
         cmake gcc-c++ git ninja-build python3
 
 # Build and run this docker by mapping shaka-packager with

--- a/packager/testing/dockers/OpenSUSE_Dockerfile
+++ b/packager/testing/dockers/OpenSUSE_Dockerfile
@@ -3,7 +3,6 @@ FROM opensuse/leap:15.5
 # Install utilities, libraries, and dev tools.
 RUN zypper in -y \
         curl which \
-        c-ares-devel \
         cmake gcc9-c++ git ninja python3
 
 # OpenSuse 15 doesn't have the required gcc 9+ by default, but we can install

--- a/packager/testing/dockers/Ubuntu_Dockerfile
+++ b/packager/testing/dockers/Ubuntu_Dockerfile
@@ -7,7 +7,6 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y apt-utils
 RUN apt-get install -y \
         curl \
-        libc-ares-dev \
         build-essential cmake git ninja-build python3
 
 # Build and run this docker by mapping shaka-packager with

--- a/packager/third_party/CMakeLists.txt
+++ b/packager/third_party/CMakeLists.txt
@@ -27,6 +27,7 @@ endif()
 
 # These all use EXCLUDE_FROM_ALL so that only the referenced targets get built.
 add_subdirectory(abseil-cpp EXCLUDE_FROM_ALL)
+add_subdirectory(c-ares EXCLUDE_FROM_ALL)
 add_subdirectory(curl EXCLUDE_FROM_ALL)
 add_subdirectory(googletest EXCLUDE_FROM_ALL)
 add_subdirectory(json EXCLUDE_FROM_ALL)

--- a/packager/third_party/c-ares/CMakeLists.txt
+++ b/packager/third_party/c-ares/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright 2023 Google LLC. All rights reserved.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file or at
+# https://developers.google.com/open-source/licenses/bsd
+
+# CMake build file to host c-ares configuration.
+
+set(CARES_STATIC ON)
+set(CARES_SHARED OFF)
+set(CARES_INSTALL OFF)
+set(CARES_STATIC_PIC OFF)
+set(CARES_BUILD_TESTS OFF)
+set(CARES_BUILD_CONTAINER_TESTS OFF)
+set(CARES_BUILD_TOOLS OFF)
+
+# With these set in scope of this folder, load the library's own CMakeLists.txt.
+add_subdirectory(source)

--- a/packager/third_party/curl/CMakeLists.txt
+++ b/packager/third_party/curl/CMakeLists.txt
@@ -16,8 +16,12 @@ set(CURL_USE_LIBSSH2 OFF)
 set(CURL_ZLIB OFF)
 
 if(UNIX AND NOT APPLE)
-  # Use libcares to fix static linking on Linux.
-  set(ENABLE_ARES ON)
+  # Use c-ares to fix static linking on Linux.  Set USE_ARES directly, not the
+  # ENABLE_ARES option that triggers a search for c-ares on the system.
+  set(USE_ARES 1)
+  # This is necessary when we hack the c-ares search, because we break the
+  # export target.  We didn't need it anyway.
+  set(CURL_ENABLE_EXPORT_TARGET OFF)
 endif()
 
 if(WIN32)
@@ -40,3 +44,9 @@ endif()
 
 # With these set in scope of this folder, load the library's own CMakeLists.txt.
 add_subdirectory(source)
+
+# Our enabling of c-ares doesn't automatically set a dependency between libcurl
+# and c-ares.  Fix that now.
+if(USE_ARES)
+  target_link_libraries(libcurl c-ares)
+endif()


### PR DESCRIPTION
c-ares (used on Linux only) was an exception to the rule of only linking against internally-built libraries.  This fixes that, to support a truly static build of packager.