### PR TITLE
fix: prevent segfault on --use_fake_clock_for_muxer

### DIFF
--- a/packager/app/muxer_factory.cc
+++ b/packager/app/muxer_factory.cc
@@ -78,7 +78,7 @@ std::shared_ptr<Muxer> MuxerFactory::CreateMuxer(
   return muxer;
 }
 
-void MuxerFactory::OverrideClock(Clock* clock) {
+void MuxerFactory::OverrideClock(std::shared_ptr<Clock> clock) {
   clock_ = clock;
 }
 }  // namespace media

--- a/packager/app/muxer_factory.h
+++ b/packager/app/muxer_factory.h
@@ -37,7 +37,7 @@ class MuxerFactory {
 
   /// For testing, if you need to replace the clock that muxers work with
   /// this will replace the clock for all muxers created after this call.
-  void OverrideClock(Clock* clock);
+  void OverrideClock(std::shared_ptr<Clock> clock);
 
   void SetTsStreamOffset(int32_t offset_ms) {
     transport_stream_timestamp_offset_ms_ = offset_ms;
@@ -50,7 +50,7 @@ class MuxerFactory {
   const Mp4OutputParams mp4_params_;
   const std::string temp_dir_;
   int32_t transport_stream_timestamp_offset_ms_ = 0;
-  Clock* clock_ = nullptr;
+  std::shared_ptr<Clock> clock_ = nullptr;
 };
 
 }  // namespace media

--- a/packager/media/base/muxer.h
+++ b/packager/media/base/muxer.h
@@ -54,7 +54,7 @@ class Muxer : public MediaHandler {
   /// If no clock is injected, the code uses std::chrone::system_clock::now()
   /// to generate the time-stamps.
   /// @param clock is the Clock to be injected.
-  void set_clock(Clock* clock) { clock_.reset(clock); }
+  void set_clock(std::shared_ptr<Clock> clock) { clock_ = clock; }
 
  protected:
   /// @name MediaHandler implementation overrides.
@@ -112,7 +112,7 @@ class Muxer : public MediaHandler {
 
   std::unique_ptr<MuxerListener> muxer_listener_;
   std::unique_ptr<ProgressListener> progress_listener_;
-  std::unique_ptr<Clock> clock_;
+  std::shared_ptr<Clock> clock_;
 
   // In VOD single segment case with Ad Cues, |output_file_name| is allowed to
   // be a template. In this case, there will be NumAdCues + 1 files generated.

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -809,7 +809,7 @@ Status CreateAllJobs(const std::vector<StreamDescriptor>& stream_descriptors,
 }  // namespace media
 
 struct Packager::PackagerInternal {
-  media::FakeClock fake_clock;
+  std::shared_ptr<media::FakeClock> fake_clock;
   std::unique_ptr<KeySource> encryption_key_source;
   std::unique_ptr<MpdNotifier> mpd_notifier;
   std::unique_ptr<hls::HlsNotifier> hls_notifier;
@@ -942,7 +942,7 @@ Status Packager::Initialize(
 
   media::MuxerFactory muxer_factory(packaging_params);
   if (packaging_params.test_params.inject_fake_clock) {
-    muxer_factory.OverrideClock(&internal->fake_clock);
+    muxer_factory.OverrideClock(internal->fake_clock);
   }
 
   media::MuxerListenerFactory muxer_listener_factory(


### PR DESCRIPTION
the option for --use_fake_clock_for_muxer was resulting in a segfault, exposed by the integration tests. Switch to using a shared_ptr for Clock.