### PR TITLE
build: Use the standard BUILD_SHARED_LIBS variable

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -123,9 +123,9 @@ jobs:
           mkdir -p build/
 
           if [[ "${{ matrix.lib_type }}" == "shared" ]]; then
-            LIBPACKAGER_SHARED="ON"
+            BUILD_SHARED_LIBS="ON"
           else
-            LIBPACKAGER_SHARED="OFF"
+            BUILD_SHARED_LIBS="OFF"
           fi
 
           # If set, override the default generator for the platform.
@@ -142,7 +142,7 @@ jobs:
 
           cmake \
             -DCMAKE_BUILD_TYPE="${{ matrix.build_type }}" \
-            -DLIBPACKAGER_SHARED="$LIBPACKAGER_SHARED" \
+            -DBUILD_SHARED_LIBS="$BUILD_SHARED_LIBS" \
             -S . \
             -B build/
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ project(shaka-packager VERSION "")
 
 # The only build option for Shaka Packager is whether to build a shared
 # libpackager library.  By default, don't.
-option(LIBPACKAGER_SHARED "Build libpackager as a shared library" OFF)
+option(BUILD_SHARED_LIBS "Build libpackager as a shared library" OFF)
 
 # Enable CMake's test infrastructure.
 enable_testing()

--- a/docs/source/build_instructions.md
+++ b/docs/source/build_instructions.md
@@ -94,7 +94,7 @@ You can change other build settings with `-D` flags to CMake, for example
 you can build a shared `libpackager` instead of static by adding
 
 ```shell
--DLIBPACKAGER_SHARED="ON"
+-DBUILD_SHARED_LIBS="ON"
 ```
 
 After configuring CMake you can run the build with

--- a/link-test/CMakeLists.txt
+++ b/link-test/CMakeLists.txt
@@ -7,7 +7,7 @@
 # If we're building a shared library, make sure it works.  We only do this for
 # a shared library because the static library won't wrap the third-party
 # dependencies like absl.
-if(LIBPACKAGER_SHARED)
+if(BUILD_SHARED_LIBS)
   # Install the library and headers to a temporary location.
   set(TEST_INSTALL_DIR ${CMAKE_BINARY_DIR}/test-install)
 

--- a/packager/CMakeLists.txt
+++ b/packager/CMakeLists.txt
@@ -9,8 +9,8 @@
 # Include a module to define standard install directories.
 include(GNUInstallDirs)
 
-# Build static libs by default, or shared if LIBPACKAGER_SHARED is defined.
-if(LIBPACKAGER_SHARED)
+# Build static libs by default, or shared if BUILD_SHARED_LIBS is on.
+if(BUILD_SHARED_LIBS)
   add_definitions(-DSHARED_LIBRARY_BUILD)
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif()
@@ -88,7 +88,7 @@ set(libpackager_sources
   ../include/packager/packager.h
   )
 
-if(LIBPACKAGER_SHARED)
+if(BUILD_SHARED_LIBS)
   add_library(libpackager SHARED ${libpackager_sources})
   target_compile_definitions(libpackager PUBLIC SHAKA_IMPLEMENTATION)
 else()

--- a/packager/file/CMakeLists.txt
+++ b/packager/file/CMakeLists.txt
@@ -29,8 +29,8 @@ target_link_libraries(file
     status
     version)
 
-if(LIBPACKAGER_SHARED)
-    target_compile_definitions(file PUBLIC SHAKA_IMPLEMENTATION)
+if(BUILD_SHARED_LIBS)
+  target_compile_definitions(file PUBLIC SHAKA_IMPLEMENTATION)
 endif()
 
 add_library(file_test_util STATIC

--- a/packager/status/CMakeLists.txt
+++ b/packager/status/CMakeLists.txt
@@ -10,7 +10,7 @@ target_link_libraries(status
     absl::log
     absl::str_format)
 
-if(LIBPACKAGER_SHARED)
+if(BUILD_SHARED_LIBS)
   target_compile_definitions(status PUBLIC SHAKA_IMPLEMENTATION)
 endif()
 


### PR DESCRIPTION
Use the standard BUILD_SHARED_LIBS variable instead of the custom LIBPACKAGER_SHARED variable