### PR TITLE
fix: Add missing <cstdint> includes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,6 +18,7 @@ Alen Vrecko <alen.vrecko@gmail.com>
 Amazon Music <*@amazon.com>
 Anders Hasselqvist <anders.hasselqvist@gmail.com>
 Audible <*@audible.com>
+Cyfrowy Polsat SA <*@cyfrowypolsat.pl>
 Chun-da Chen <capitalm.c@gmail.com>
 Daniel Cantarín <canta@canta.com.ar>
 Dolby Laboratories <*@dolby.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -40,6 +40,7 @@ Kongqun Yang <kqyang@google.com>
 Leandro Moreira <leandro.ribeiro.moreira@gmail.com>
 Leo Law <leoltlaw.gh@gmail.com>
 Marcus Spangenberg <marcus.spangenberg@eyevinn.se>
+Michal Wierzbicki <mwierzbicki1@cyfrowypolsat.pl>
 Ole Andre Birkedal <o.birkedal@sportradar.com>
 Piotr Srebrny <srebrny.piotr@gmail.com>
 Qingquan Wang <wangqq1103@gmail.com>

--- a/packager/hls/base/tag.h
+++ b/packager/hls/base/tag.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_HLS_BASE_TAG_H_
 #define PACKAGER_HLS_BASE_TAG_H_
 
+#include <cstdint>
 #include <string>
 
 namespace shaka {

--- a/packager/hls/public/hls_params.h
+++ b/packager/hls/public/hls_params.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_HLS_PUBLIC_HLS_PARAMS_H_
 #define PACKAGER_HLS_PUBLIC_HLS_PARAMS_H_
 
+#include <cstdint>
 #include <string>
 
 namespace shaka {

--- a/packager/media/base/buffer_writer.h
+++ b/packager/media/base/buffer_writer.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_BASE_BUFFER_WRITER_H_
 #define PACKAGER_MEDIA_BASE_BUFFER_WRITER_H_
 
+#include <cstdint>
 #include <vector>
 
 #include "packager/base/macros.h"

--- a/packager/media/base/fourccs.h
+++ b/packager/media/base/fourccs.h
@@ -5,6 +5,7 @@
 #ifndef PACKAGER_MEDIA_BASE_FOURCCS_H_
 #define PACKAGER_MEDIA_BASE_FOURCCS_H_
 
+#include <cstdint>
 #include <string>
 
 namespace shaka {

--- a/packager/media/base/id3_tag.h
+++ b/packager/media/base/id3_tag.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_BASE_ID3_TAG_H_
 #define PACKAGER_MEDIA_BASE_ID3_TAG_H_
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/packager/media/base/id3_tag_unittest.cc
+++ b/packager/media/base/id3_tag_unittest.cc
@@ -4,6 +4,8 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+#include <cstdint>
+
 #include "packager/media/base/id3_tag.h"
 
 #include <gmock/gmock.h>

--- a/packager/packager.h
+++ b/packager/packager.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_PACKAGER_H_
 #define PACKAGER_PACKAGER_H_
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>


### PR DESCRIPTION
CC version 13 needs `<cstdint>` to be explicitly included to
provide fixed bits integer types.

Some files using it inludes `<stdint.h>`, some are missing direct or undirect inclusion. This PR adds `<cstdint>` inclusion to the
minimal set of files, allowing compilation on GCC 13.

Closes #1305
