### PR TITLE
fix: preserve case for stream descriptors

### DIFF
--- a/packager/utils/string_trim_split.cc
+++ b/packager/utils/string_trim_split.cc
@@ -11,8 +11,7 @@
 namespace shaka {
 std::vector<std::string> SplitAndTrimSkipEmpty(const std::string& str,
                                                char delimiter) {
-  auto tokens =
-      absl::StrSplit(absl::AsciiStrToLower(str), delimiter, absl::SkipEmpty());
+  auto tokens = absl::StrSplit(str, delimiter, absl::SkipEmpty());
   std::vector<std::string> results;
   for (const absl::string_view& token : tokens) {
     std::string trimmed = std::string(token);


### PR DESCRIPTION
The accidental tolower in `SplitAndTrimSkipEmpty` was causing stream descriptors to not preserve case for certain things like accessibilities.