### PR TITLE
test: fix fake clock for muxer for integration tests

### DIFF
--- a/packager/media/formats/mp4/mp4_muxer.cc
+++ b/packager/media/formats/mp4/mp4_muxer.cc
@@ -692,10 +692,7 @@ uint64_t MP4Muxer::IsoTimeNow() {
   const uint64_t kIsomTimeOffset = 2082844800l;
 
   // Get the current system time since January 1, 1970, in seconds.
-  std::chrono::system_clock::duration duration =
-      std::chrono::system_clock::now().time_since_epoch();
-  std::int64_t secondsSince1970 =
-      std::chrono::duration_cast<std::chrono::seconds>(duration).count();
+  std::int64_t secondsSince1970 = Now();
 
   // Add the offset of seconds between January 1, 1970, and January 1, 1904.
   return secondsSince1970 + kIsomTimeOffset;

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -942,6 +942,7 @@ Status Packager::Initialize(
 
   media::MuxerFactory muxer_factory(packaging_params);
   if (packaging_params.test_params.inject_fake_clock) {
+    internal->fake_clock.reset(new media::FakeClock());
     muxer_factory.OverrideClock(internal->fake_clock);
   }
 


### PR DESCRIPTION
The fix in #1289 was not complete and left the fake clock as null which didn't have any effect. This was revealed by integration tests showing mismatches in the timestamps in MP4.