### PR TITLE
feat: default text zero bias

### DIFF
--- a/include/packager/packager.h
+++ b/include/packager/packager.h
@@ -46,6 +46,10 @@ struct PackagingParams {
   /// audio) timestamps to compensate for possible negative timestamps in the
   /// input.
   int32_t transport_stream_timestamp_offset_ms = 0;
+  // the threshold used to determine if we should assume that the text stream
+  // actually starts at time zero
+  int32_t default_text_zero_bias_ms = 0;
+
   /// Chunking (segmentation) related parameters.
   ChunkingParams chunking_params;
 

--- a/packager/app/muxer_flags.cc
+++ b/packager/app/muxer_flags.cc
@@ -62,13 +62,14 @@ ABSL_FLAG(int32_t,
           "input. For example, timestamps from ISO-BMFF after adjusted by "
           "EditList could be negative. In transport streams, timestamps are "
           "not allowed to be less than zero.");
-ABSL_FLAG(int32_t,
-             default_text_zero_bias_ms,
-             0,
-             "A positive value, in milliseconds. It is the threshold used to "
-             "determine if we should assume that the text stream actually starts "
-             "at time zero. If the first sample comes before default_text_zero_bias_ms, "
-             "then the start will be padded as the stream is assumed to start at zero. "
-             "If the first sample comes after default_text_zero_bias_ms then the start "
-             "of the stream will not be padded as we cannot assume the start time of "
-             "the stream.");          
+ABSL_FLAG(
+    int32_t,
+    default_text_zero_bias_ms,
+    0,
+    "A positive value, in milliseconds. It is the threshold used to "
+    "determine if we should assume that the text stream actually starts "
+    "at time zero. If the first sample comes before default_text_zero_bias_ms, "
+    "then the start will be padded as the stream is assumed to start at zero. "
+    "If the first sample comes after default_text_zero_bias_ms then the start "
+    "of the stream will not be padded as we cannot assume the start time of "
+    "the stream.");

--- a/packager/app/muxer_flags.cc
+++ b/packager/app/muxer_flags.cc
@@ -62,3 +62,13 @@ ABSL_FLAG(int32_t,
           "input. For example, timestamps from ISO-BMFF after adjusted by "
           "EditList could be negative. In transport streams, timestamps are "
           "not allowed to be less than zero.");
+ABSL_FLAG(int32_t,
+             default_text_zero_bias_ms,
+             0,
+             "A positive value, in milliseconds. It is the threshold used to "
+             "determine if we should assume that the text stream actually starts "
+             "at time zero. If the first sample comes before default_text_zero_bias_ms, "
+             "then the start will be padded as the stream is assumed to start at zero. "
+             "If the first sample comes after default_text_zero_bias_ms then the start "
+             "of the stream will not be padded as we cannot assume the start time of "
+             "the stream.");          

--- a/packager/app/muxer_flags.h
+++ b/packager/app/muxer_flags.h
@@ -21,5 +21,6 @@ ABSL_DECLARE_FLAG(bool, generate_sidx_in_media_segments);
 ABSL_DECLARE_FLAG(std::string, temp_dir);
 ABSL_DECLARE_FLAG(bool, mp4_include_pssh_in_stream);
 ABSL_DECLARE_FLAG(int32_t, transport_stream_timestamp_offset_ms);
+ABSL_DECLARE_FLAG(int32_t, default_text_zero_bias_ms);
 
 #endif  // APP_MUXER_FLAGS_H_

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -461,7 +461,7 @@ std::optional<PackagingParams> GetPackagingParams() {
 
   packaging_params.transport_stream_timestamp_offset_ms =
       absl::GetFlag(FLAGS_transport_stream_timestamp_offset_ms);
-  packaging_params.default_text_zero_bias_ms = 
+  packaging_params.default_text_zero_bias_ms =
       absl::GetFlag(FLAGS_default_text_zero_bias_ms);
 
   packaging_params.output_media_info = absl::GetFlag(FLAGS_output_media_info);

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -461,6 +461,8 @@ std::optional<PackagingParams> GetPackagingParams() {
 
   packaging_params.transport_stream_timestamp_offset_ms =
       absl::GetFlag(FLAGS_transport_stream_timestamp_offset_ms);
+  packaging_params.default_text_zero_bias_ms = 
+      absl::GetFlag(FLAGS_default_text_zero_bias_ms);
 
   packaging_params.output_media_info = absl::GetFlag(FLAGS_output_media_info);
 

--- a/packager/media/formats/webvtt/text_padder.cc
+++ b/packager/media/formats/webvtt/text_padder.cc
@@ -40,7 +40,7 @@ Status TextPadder::OnTextSample(std::unique_ptr<StreamData> data) {
   // start at time zero.
   if (max_end_time_ms_ < 0) {
     max_end_time_ms_ =
-        sample.start_time() > zero_start_bias_ms_ ? sample.start_time() : 0;
+        zero_start_bias_ms_ && sample.start_time() > zero_start_bias_ms_ ? sample.start_time() : 0;
   }
 
   // Check if there will be a gap between samples if we just dispatch this

--- a/packager/media/formats/webvtt/text_padder.cc
+++ b/packager/media/formats/webvtt/text_padder.cc
@@ -40,7 +40,9 @@ Status TextPadder::OnTextSample(std::unique_ptr<StreamData> data) {
   // start at time zero.
   if (max_end_time_ms_ < 0) {
     max_end_time_ms_ =
-        zero_start_bias_ms_ && sample.start_time() > zero_start_bias_ms_ ? sample.start_time() : 0;
+        zero_start_bias_ms_ && sample.start_time() > zero_start_bias_ms_
+            ? sample.start_time()
+            : 0;
   }
 
   // Check if there will be a gap between samples if we just dispatch this

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -59,8 +59,6 @@ namespace {
 
 const char kMediaInfoSuffix[] = ".media_info";
 
-const int64_t kDefaultTextZeroBiasMs = 10 * 60 * 1000;  // 10 minutes
-
 MuxerListenerFactory::StreamData ToMuxerListenerData(
     const StreamDescriptor& stream) {
   MuxerListenerFactory::StreamData data;
@@ -663,7 +661,7 @@ Status CreateAudioVideoJobs(
       std::vector<std::shared_ptr<MediaHandler>> handlers;
       if (is_text) {
         handlers.emplace_back(
-            std::make_shared<TextPadder>(kDefaultTextZeroBiasMs));
+            std::make_shared<TextPadder>(packaging_params.default_text_zero_bias_ms));
       }
       if (sync_points) {
         handlers.emplace_back(cue_aligner);

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -660,8 +660,8 @@ Status CreateAudioVideoJobs(
 
       std::vector<std::shared_ptr<MediaHandler>> handlers;
       if (is_text) {
-        handlers.emplace_back(
-            std::make_shared<TextPadder>(packaging_params.default_text_zero_bias_ms));
+        handlers.emplace_back(std::make_shared<TextPadder>(
+            packaging_params.default_text_zero_bias_ms));
       }
       if (sync_points) {
         handlers.emplace_back(cue_aligner);


### PR DESCRIPTION
A positive value, in milliseconds. It is the threshold used to determine if we should assume that the text stream actually starts at time zero. If the first sample comes before default_text_zero_bias_ms, then the start will be padded as the stream is assumed to start at zero. If the first sample comes after default_text_zero_bias_ms then the start of the stream will not be padded as we cannot assume the start time of the stream.