### PR TITLE
build: Fix absl log flags being stripped

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -100,9 +100,24 @@ jobs:
       - name: Install Linux deps
         if: runner.os == 'Linux'
         # NOTE: CMake is already installed in GitHub Actions VMs, but not
-        # necessarily in a self-hosted runner.
+        # necessarily in a self-hosted runner.  We also need a minimum version
+        # that may be greater than what is available in Ubuntu, so we set up
+        # the official CMake PPA first.
         run: |
-          sudo apt update && sudo apt install -y \
+          kitware_key_url="https://apt.kitware.com/keys/kitware-archive-latest.asc"
+          kitware_key_path="/usr/share/keyrings/kitware-archive-keyring.gpg"
+          kitware_sources_path="/etc/apt/sources.list.d/kitware.list"
+
+          wget -O - "$kitware_key_url" 2>/dev/null | gpg --dearmor - \
+              | sudo tee "$kitware_key_path" >/dev/null
+
+          . /etc/lsb-release  # Defines $DISTRIB_CODENAME (jammy, focal, etc)
+
+          echo "deb [signed-by=$kitware_key_path] https://apt.kitware.com/ubuntu/ $DISTRIB_CODENAME main" \
+              | sudo tee "$kitware_sources_path" >/dev/null
+
+          sudo apt update
+          sudo apt install -y \
               cmake \
               ninja-build
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # Root-level CMake build file.
 
 # Minimum CMake version.  This must be in the root level CMakeLists.txt.
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.24)
 
 # These policy settings should be included before the project definition.
 include("packager/policies.cmake")

--- a/docs/source/build_instructions.md
+++ b/docs/source/build_instructions.md
@@ -17,6 +17,9 @@ sudo apt-get install -y \
 
 Note that `git` must be v1.7.6 or above to support relative paths in submodules.
 
+Note also that `cmake` must be v3.24 or above to support a linker setting
+needed for `absl::log_flags`.
+
 ## Mac system requirements
 
  * [Xcode](https://developer.apple.com/xcode) 7.3+.

--- a/packager/CMakeLists.txt
+++ b/packager/CMakeLists.txt
@@ -177,7 +177,8 @@ target_link_libraries(packager
   absl::flags
   absl::flags_parse
   absl::log
-  absl::log_flags
+  # See https://github.com/abseil/abseil-cpp/blob/c14dfbf9/absl/log/CMakeLists.txt#L464-L467
+  $<LINK_LIBRARY:WHOLE_ARCHIVE,absl::log_flags>
   absl::strings
   hex_bytes_flags
   libpackager
@@ -193,7 +194,8 @@ target_link_libraries(mpd_generator
   absl::flags
   absl::flags_parse
   absl::log
-  absl::log_flags
+  # See https://github.com/abseil/abseil-cpp/blob/c14dfbf9/absl/log/CMakeLists.txt#L464-L467
+  $<LINK_LIBRARY:WHOLE_ARCHIVE,absl::log_flags>
   absl::strings
   license_notice
   mpd_builder

--- a/packager/testing/dockers/Debian_Dockerfile
+++ b/packager/testing/dockers/Debian_Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11
+FROM debian:12
 
 # Install utilities, libraries, and dev tools.
 RUN apt-get update && apt-get install -y apt-utils

--- a/packager/testing/dockers/Fedora_Dockerfile
+++ b/packager/testing/dockers/Fedora_Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:34
+FROM fedora:35
 
 # Install utilities, libraries, and dev tools.
 RUN yum install -y \

--- a/packager/testing/dockers/OpenSUSE_Dockerfile
+++ b/packager/testing/dockers/OpenSUSE_Dockerfile
@@ -1,11 +1,17 @@
 FROM opensuse/leap:15.5
 
+# OpenSUSE 15.5 doesn't have the required CMake 3.24+, but we can add it
+# through another repo:
+RUN zypper addrepo \
+    https://download.opensuse.org/repositories/devel:tools:building/15.5/devel:tools:building.repo
+RUN zypper --no-gpg-checks refresh
+
 # Install utilities, libraries, and dev tools.
 RUN zypper in -y \
         curl which \
         cmake gcc9-c++ git ninja python3
 
-# OpenSuse 15 doesn't have the required gcc 9+ by default, but we can install
+# OpenSUSE 15.5 doesn't have the required gcc 9+ by default, but we can install
 # it as gcc9 and symlink it.
 RUN ln -s g++-9 /usr/bin/g++
 RUN ln -s gcc-9 /usr/bin/gcc

--- a/packager/testing/dockers/Ubuntu_Dockerfile
+++ b/packager/testing/dockers/Ubuntu_Dockerfile
@@ -7,7 +7,18 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y apt-utils
 RUN apt-get install -y \
         curl \
-        build-essential cmake git ninja-build python3
+        build-essential git ninja-build python3 wget
+
+# Install the official CMake repo to get CMake v3.24+:
+ENV kitware_key_url https://apt.kitware.com/keys/kitware-archive-latest.asc
+ENV kitware_key_path /usr/share/keyrings/kitware-archive-keyring.gpg
+ENV kitware_sources_path /etc/apt/sources.list.d/kitware.list
+ENV DISTRIB_CODENAME jammy
+
+RUN wget -O - "$kitware_key_url" 2>/dev/null | gpg --dearmor - > "$kitware_key_path"
+RUN echo "deb [signed-by=$kitware_key_path] https://apt.kitware.com/ubuntu/ $DISTRIB_CODENAME main" > "$kitware_sources_path"
+
+RUN apt-get update && apt-get install -y cmake
 
 # Build and run this docker by mapping shaka-packager with
 # -v "shaka-packager:/shaka-packager".

--- a/packager/testing/dockers/Ubuntu_Dockerfile
+++ b/packager/testing/dockers/Ubuntu_Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 # Tell apt not to prompt us for anything.
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
According to a comment in
packager/third_party/abseil-cpp/source/absl/log/CMakeLists.txt, many linkers will strip the contents of absl::log_flags because its symbols symbols are only used in a global constructor, and that for now, clients should link using
$<LINK_LIBRARY:WHOLE_ARCHIVE,absl::log_flags>.

Closes #1325