### PR TITLE
feat: add startwithSAP/subsegmentstartswithSAP for audio tracks

### DIFF
--- a/packager/app/test/testdata/acc-he/output.mpd
+++ b/packager/app/test/testdata/acc-he/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.763175S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <Representation id="0" bandwidth="73677" codecs="mp4a.40.5" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <BaseURL>bear-640x360-aac_he-silent_right-audio.mp4</BaseURL>

--- a/packager/app/test/testdata/audio-video-with-accessibilities-and-roles/output.mpd
+++ b/packager/app/test/testdata/audio-video-with-accessibilities-and-roles/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value="1"/>
       <Role schemeIdUri="urn:mpeg:dash:role:2011" value="description"/>
       <Representation id="0" bandwidth="133334" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">

--- a/packager/app/test/testdata/audio-video-with-codec-switching-and-forced-commandline_order/output.mpd
+++ b/packager/app/test/testdata/audio-video-with-codec-switching-and-forced-commandline_order/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.8028S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <Representation id="0" bandwidth="133334" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <BaseURL>bear-640x360-audio.mp4</BaseURL>

--- a/packager/app/test/testdata/audio-video-with-codec-switching-encryption-trick-play/output.mpd
+++ b/packager/app/test/testdata/audio-video-with-codec-switching-encryption-trick-play/output.mpd
@@ -49,7 +49,7 @@
         </SegmentBase>
       </Representation>
     </AdaptationSet>
-    <AdaptationSet id="3" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="3" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="31323334-3536-3738-3930-313233343536"/>
       <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b">
         <cenc:pssh>AAAANHBzc2gBAAAAEHfv7MCyTQKs4zweUuL7SwAAAAExMjM0NTY3ODkwMTIzNDU2AAAAAA==</cenc:pssh>

--- a/packager/app/test/testdata/audio-video-with-codec-switching/output.mpd
+++ b/packager/app/test/testdata/audio-video-with-codec-switching/output.mpd
@@ -28,7 +28,7 @@
         </SegmentBase>
       </Representation>
     </AdaptationSet>
-    <AdaptationSet id="2" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="2" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <Representation id="3" bandwidth="133334" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <BaseURL>bear-640x360-audio.mp4</BaseURL>

--- a/packager/app/test/testdata/audio-video-with-language-override-with-subtag/output.mpd
+++ b/packager/app/test/testdata/audio-video-with-language-override-with-subtag/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" lang="pt-BR" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" lang="pt-BR" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <Representation id="0" bandwidth="133334" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <BaseURL>bear-640x360-audio.mp4</BaseURL>

--- a/packager/app/test/testdata/audio-video-with-language-override/output.mpd
+++ b/packager/app/test/testdata/audio-video-with-language-override/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" lang="pt" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" lang="pt" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
       <Representation id="0" bandwidth="133334" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>

--- a/packager/app/test/testdata/audio-video-with-trick-play-and-forced-commandline-order/output.mpd
+++ b/packager/app/test/testdata/audio-video-with-trick-play-and-forced-commandline-order/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.8028S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <Representation id="0" bandwidth="133334" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <BaseURL>bear-640x360-audio.mp4</BaseURL>

--- a/packager/app/test/testdata/audio-video-with-trick-play/output.mpd
+++ b/packager/app/test/testdata/audio-video-with-trick-play/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <Representation id="0" bandwidth="133334" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <BaseURL>bear-640x360-audio.mp4</BaseURL>

--- a/packager/app/test/testdata/audio-video-with-two-trick-play/output.mpd
+++ b/packager/app/test/testdata/audio-video-with-two-trick-play/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <Representation id="0" bandwidth="133334" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <BaseURL>bear-640x360-audio.mp4</BaseURL>

--- a/packager/app/test/testdata/audio-video/output.mpd
+++ b/packager/app/test/testdata/audio-video/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <Representation id="0" bandwidth="133334" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <BaseURL>bear-640x360-audio.mp4</BaseURL>

--- a/packager/app/test/testdata/avc-aac-ts/output.mpd
+++ b/packager/app/test/testdata/avc-aac-ts/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="PT2S" type="dynamic" publishTime="some_time" availabilityStartTime="some_time" minimumUpdatePeriod="PT5S" timeShiftBufferDepth="PT1800S">
   <Period id="0" start="PT0S">
-    <AdaptationSet id="0" contentType="audio" segmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" startWithSAP="1" segmentAlignment="true">
       <Representation id="0" bandwidth="194319" codecs="mp4a.40.2" mimeType="audio/MP2T" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <SegmentTemplate timescale="90000" media="bear-640x360-audio-$Number$.ts" startNumber="1">

--- a/packager/app/test/testdata/avc-ts-live-playlist-dash-dynamic-with-segment-deletion/output.mpd
+++ b/packager/app/test/testdata/avc-ts-live-playlist-dash-dynamic-with-segment-deletion/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="PT2S" type="dynamic" publishTime="some_time" availabilityStartTime="some_time" minimumUpdatePeriod="PT5S" timeShiftBufferDepth="PT0.5S">
   <Period id="0" start="PT0S">
-    <AdaptationSet id="0" contentType="audio" segmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" startWithSAP="1" segmentAlignment="true">
       <Representation id="0" bandwidth="133919" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <SegmentTemplate timescale="90000" initialization="bear-640x360-audio-init.mp4" media="bear-640x360-audio-$Number$.m4s" startNumber="4">

--- a/packager/app/test/testdata/bandwidth-override/output.mpd
+++ b/packager/app/test/testdata/bandwidth-override/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <Representation id="0" bandwidth="11111" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <BaseURL>bear-640x360-audio.mp4</BaseURL>

--- a/packager/app/test/testdata/dash-label/output.mpd
+++ b/packager/app/test/testdata/dash-label/output.mpd
@@ -11,7 +11,7 @@
         </SegmentBase>
       </Representation>
     </AdaptationSet>
-    <AdaptationSet id="1" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="1" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <Label>English</Label>
       <Representation id="1" bandwidth="133334" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>

--- a/packager/app/test/testdata/encryption-and-ad-cues-and-dash-trick-play/output.mpd
+++ b/packager/app/test/testdata/encryption-and-ad-cues-and-dash-trick-play/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns:cenc="urn:mpeg:cenc:2013" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0" duration="PT2.002S">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="31323334-3536-3738-3930-313233343536"/>
       <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b">
         <cenc:pssh>AAAANHBzc2gBAAAAEHfv7MCyTQKs4zweUuL7SwAAAAExMjM0NTY3ODkwMTIzNDU2AAAAAA==</cenc:pssh>
@@ -42,7 +42,7 @@
     </AdaptationSet>
   </Period>
   <Period id="1" duration="PT0.734067S">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="31323334-3536-3738-3930-313233343536"/>
       <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b">
         <cenc:pssh>AAAANHBzc2gBAAAAEHfv7MCyTQKs4zweUuL7SwAAAAExMjM0NTY3ODkwMTIzNDU2AAAAAA==</cenc:pssh>

--- a/packager/app/test/testdata/encryption-and-ad-cues-split-content/output.mpd
+++ b/packager/app/test/testdata/encryption-and-ad-cues-split-content/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns:cenc="urn:mpeg:cenc:2013" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0" duration="PT2.002S">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="31323334-3536-3738-3930-313233343536"/>
       <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b">
         <cenc:pssh>AAAANHBzc2gBAAAAEHfv7MCyTQKs4zweUuL7SwAAAAExMjM0NTY3ODkwMTIzNDU2AAAAAA==</cenc:pssh>
@@ -29,7 +29,7 @@
     </AdaptationSet>
   </Period>
   <Period id="1" duration="PT0.734067S">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="31323334-3536-3738-3930-313233343536"/>
       <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b">
         <cenc:pssh>AAAANHBzc2gBAAAAEHfv7MCyTQKs4zweUuL7SwAAAAExMjM0NTY3ODkwMTIzNDU2AAAAAA==</cenc:pssh>

--- a/packager/app/test/testdata/encryption-and-ad-cues/output.mpd
+++ b/packager/app/test/testdata/encryption-and-ad-cues/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns:cenc="urn:mpeg:cenc:2013" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0" duration="PT2.002S">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="31323334-3536-3738-3930-313233343536"/>
       <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b">
         <cenc:pssh>AAAANHBzc2gBAAAAEHfv7MCyTQKs4zweUuL7SwAAAAExMjM0NTY3ODkwMTIzNDU2AAAAAA==</cenc:pssh>
@@ -29,7 +29,7 @@
     </AdaptationSet>
   </Period>
   <Period id="1" duration="PT0.734067S">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="31323334-3536-3738-3930-313233343536"/>
       <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b">
         <cenc:pssh>AAAANHBzc2gBAAAAEHfv7MCyTQKs4zweUuL7SwAAAAExMjM0NTY3ODkwMTIzNDU2AAAAAA==</cenc:pssh>

--- a/packager/app/test/testdata/encryption-and-no-clear-lead/output.mpd
+++ b/packager/app/test/testdata/encryption-and-no-clear-lead/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns:cenc="urn:mpeg:cenc:2013" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="31323334-3536-3738-3930-313233343536"/>
       <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b">
         <cenc:pssh>AAAANHBzc2gBAAAAEHfv7MCyTQKs4zweUuL7SwAAAAExMjM0NTY3ODkwMTIzNDU2AAAAAA==</cenc:pssh>

--- a/packager/app/test/testdata/encryption-and-no-pssh-in-stream/output.mpd
+++ b/packager/app/test/testdata/encryption-and-no-pssh-in-stream/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns:cenc="urn:mpeg:cenc:2013" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="31323334-3536-3738-3930-313233343536"/>
       <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b">
         <cenc:pssh>AAAANHBzc2gBAAAAEHfv7MCyTQKs4zweUuL7SwAAAAExMjM0NTY3ODkwMTIzNDU2AAAAAA==</cenc:pssh>

--- a/packager/app/test/testdata/encryption-and-non-dash-if-iop/output.mpd
+++ b/packager/app/test/testdata/encryption-and-non-dash-if-iop/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns:cenc="urn:mpeg:cenc:2013" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <Representation id="0" bandwidth="133663" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="31323334-3536-3738-3930-313233343536"/>

--- a/packager/app/test/testdata/encryption-and-output-media-info-and-mpd-from-media-info-segmentlist/output.mpd
+++ b/packager/app/test/testdata/encryption-and-output-media-info-and-mpd-from-media-info-segmentlist/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns:cenc="urn:mpeg:cenc:2013" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.739955S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="31323334-3536-3738-3930-313233343536"/>
       <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b">
         <cenc:pssh>AAAANHBzc2gBAAAAEHfv7MCyTQKs4zweUuL7SwAAAAExMjM0NTY3ODkwMTIzNDU2AAAAAA==</cenc:pssh>

--- a/packager/app/test/testdata/encryption-and-trick-play/output.mpd
+++ b/packager/app/test/testdata/encryption-and-trick-play/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns:cenc="urn:mpeg:cenc:2013" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="31323334-3536-3738-3930-313233343536"/>
       <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b">
         <cenc:pssh>AAAANHBzc2gBAAAAEHfv7MCyTQKs4zweUuL7SwAAAAExMjM0NTY3ODkwMTIzNDU2AAAAAA==</cenc:pssh>

--- a/packager/app/test/testdata/encryption-and-two-trick-plays/output.mpd
+++ b/packager/app/test/testdata/encryption-and-two-trick-plays/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns:cenc="urn:mpeg:cenc:2013" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="31323334-3536-3738-3930-313233343536"/>
       <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b">
         <cenc:pssh>AAAANHBzc2gBAAAAEHfv7MCyTQKs4zweUuL7SwAAAAExMjM0NTY3ODkwMTIzNDU2AAAAAA==</cenc:pssh>

--- a/packager/app/test/testdata/encryption-cbc-1/output.mpd
+++ b/packager/app/test/testdata/encryption-cbc-1/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns:cenc="urn:mpeg:cenc:2013" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <ContentProtection value="cbc1" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="31323334-3536-3738-3930-313233343536"/>
       <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b">
         <cenc:pssh>AAAANHBzc2gBAAAAEHfv7MCyTQKs4zweUuL7SwAAAAExMjM0NTY3ODkwMTIzNDU2AAAAAA==</cenc:pssh>

--- a/packager/app/test/testdata/encryption-cbcs-with-full-protection/output.mpd
+++ b/packager/app/test/testdata/encryption-cbcs-with-full-protection/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns:cenc="urn:mpeg:cenc:2013" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <ContentProtection value="cbcs" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="31323334-3536-3738-3930-313233343536"/>
       <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b">
         <cenc:pssh>AAAANHBzc2gBAAAAEHfv7MCyTQKs4zweUuL7SwAAAAExMjM0NTY3ODkwMTIzNDU2AAAAAA==</cenc:pssh>

--- a/packager/app/test/testdata/encryption-cbcs/output.mpd
+++ b/packager/app/test/testdata/encryption-cbcs/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns:cenc="urn:mpeg:cenc:2013" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <ContentProtection value="cbcs" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="31323334-3536-3738-3930-313233343536"/>
       <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b">
         <cenc:pssh>AAAANHBzc2gBAAAAEHfv7MCyTQKs4zweUuL7SwAAAAExMjM0NTY3ODkwMTIzNDU2AAAAAA==</cenc:pssh>

--- a/packager/app/test/testdata/encryption-cens/output.mpd
+++ b/packager/app/test/testdata/encryption-cens/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns:cenc="urn:mpeg:cenc:2013" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <ContentProtection value="cens" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="31323334-3536-3738-3930-313233343536"/>
       <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b">
         <cenc:pssh>AAAANHBzc2gBAAAAEHfv7MCyTQKs4zweUuL7SwAAAAExMjM0NTY3ODkwMTIzNDU2AAAAAA==</cenc:pssh>

--- a/packager/app/test/testdata/encryption-multi-keys-with-stream-label/output.mpd
+++ b/packager/app/test/testdata/encryption-multi-keys-with-stream-label/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns:cenc="urn:mpeg:cenc:2013" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="20212223-2425-2627-2829-303132333435"/>
       <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b">
         <cenc:pssh>AAAARHBzc2gBAAAAEHfv7MCyTQKs4zweUuL7SwAAAAIQERITFBUWFxgZICEiIyQlICEiIyQlJicoKTAxMjM0NQAAAAA=</cenc:pssh>

--- a/packager/app/test/testdata/encryption-multi-keys/output.mpd
+++ b/packager/app/test/testdata/encryption-multi-keys/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns:cenc="urn:mpeg:cenc:2013" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="10111213-1415-1617-1819-202122232425"/>
       <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b">
         <cenc:pssh>AAAARHBzc2gBAAAAEHfv7MCyTQKs4zweUuL7SwAAAAIQERITFBUWFxgZICEiIyQlICEiIyQlJicoKTAxMjM0NQAAAAA=</cenc:pssh>

--- a/packager/app/test/testdata/encryption-of-only-video-stream/output.mpd
+++ b/packager/app/test/testdata/encryption-of-only-video-stream/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns:cenc="urn:mpeg:cenc:2013" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <Representation id="0" bandwidth="133334" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <BaseURL>bear-640x360-audio-skip_encryption.mp4</BaseURL>

--- a/packager/app/test/testdata/encryption-using-explicit-pssh/output.mpd
+++ b/packager/app/test/testdata/encryption-using-explicit-pssh/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns:cenc="urn:mpeg:cenc:2013" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="31323334-3536-3738-3930-313233343536"/>
       <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b">
         <cenc:pssh>AAAAIHBzc2gAAAAAEHfv7MCyTQKs4zweUuL7SwAAAAA=</cenc:pssh>

--- a/packager/app/test/testdata/encryption-using-fixed-key/output.mpd
+++ b/packager/app/test/testdata/encryption-using-fixed-key/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns:cenc="urn:mpeg:cenc:2013" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="31323334-3536-3738-3930-313233343536"/>
       <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b">
         <cenc:pssh>AAAANHBzc2gBAAAAEHfv7MCyTQKs4zweUuL7SwAAAAExMjM0NTY3ODkwMTIzNDU2AAAAAA==</cenc:pssh>

--- a/packager/app/test/testdata/encryption-with-multi-drms/output.mpd
+++ b/packager/app/test/testdata/encryption-with-multi-drms/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:mas="urn:marlin:mas:1-0:services:schemas:mpd" xmlns:mspr="urn:microsoft:playready" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="31323334-3536-3738-3930-313233343536"/>
       <ContentProtection value="MSPR 2.0" schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95">
         <cenc:pssh>AAACJnBzc2gAAAAAmgTweZhAQoarkuZb4IhflQAAAgYGAgAAAQABAPwBPABXAFIATQBIAEUAQQBEAEUAUgAgAHgAbQBsAG4AcwA9ACIAaAB0AHQAcAA6AC8ALwBzAGMAaABlAG0AYQBzAC4AbQBpAGMAcgBvAHMAbwBmAHQALgBjAG8AbQAvAEQAUgBNAC8AMgAwADAANwAvADAAMwAvAFAAbABhAHkAUgBlAGEAZAB5AEgAZQBhAGQAZQByACIAIAB2AGUAcgBzAGkAbwBuAD0AIgA0AC4AMAAuADAALgAwACIAPgA8AEQAQQBUAEEAPgA8AFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBFAFkATABFAE4APgAxADYAPAAvAEsARQBZAEwARQBOAD4APABBAEwARwBJAEQAPgBBAEUAUwBDAFQAUgA8AC8AQQBMAEcASQBEAD4APAAvAFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBJAEQAPgBOAEQATQB5AE0AVABZADEATwBEAGMANQBNAEQARQB5AE0AegBRADEATgBnAD0APQA8AC8ASwBJAEQAPgA8AEMASABFAEMASwBTAFUATQA+AGwANQBMAG8AVQBnAEsAOQBLAEMAZwA9ADwALwBDAEgARQBDAEsAUwBVAE0APgA8AC8ARABBAFQAQQA+ADwALwBXAFIATQBIAEUAQQBEAEUAUgA+AA==</cenc:pssh>

--- a/packager/app/test/testdata/encryption/output.mpd
+++ b/packager/app/test/testdata/encryption/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns:cenc="urn:mpeg:cenc:2013" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="31323334-3536-3738-3930-313233343536"/>
       <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b">
         <cenc:pssh>AAAANHBzc2gBAAAAEHfv7MCyTQKs4zweUuL7SwAAAAExMjM0NTY3ODkwMTIzNDU2AAAAAA==</cenc:pssh>

--- a/packager/app/test/testdata/forced-commandline-ordering/output.mpd
+++ b/packager/app/test/testdata/forced-commandline-ordering/output.mpd
@@ -8,7 +8,7 @@
         <BaseURL>bear-english-text.vtt</BaseURL>
       </Representation>
     </AdaptationSet>
-    <AdaptationSet id="1" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="1" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <Representation id="1" bandwidth="133334" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <BaseURL>bear-640x360-audio.mp4</BaseURL>

--- a/packager/app/test/testdata/forced-subtitle/output.mpd
+++ b/packager/app/test/testdata/forced-subtitle/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <Representation id="0" bandwidth="133334" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <BaseURL>bear-640x360-audio.mp4</BaseURL>

--- a/packager/app/test/testdata/hls-only-dash-only-captions/output.mpd
+++ b/packager/app/test/testdata/hls-only-dash-only-captions/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="PT2S" type="dynamic" publishTime="some_time" availabilityStartTime="some_time" minimumUpdatePeriod="PT5S" timeShiftBufferDepth="PT1800S">
   <Period id="0" start="PT0S">
-    <AdaptationSet id="0" contentType="audio" segmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" startWithSAP="1" segmentAlignment="true">
       <Representation id="0" bandwidth="133961" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <SegmentTemplate timescale="44100" initialization="bear-640x360-audio-init.mp4" media="bear-640x360-audio-$Number$.m4s" startNumber="1">

--- a/packager/app/test/testdata/hls-only-dash-only/output.mpd
+++ b/packager/app/test/testdata/hls-only-dash-only/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.739955S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <Representation id="1" bandwidth="133334" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <BaseURL>bear-640x360-audio.mp4</BaseURL>

--- a/packager/app/test/testdata/live-profile-and-encryption-and-mult-files/output.mpd
+++ b/packager/app/test/testdata/live-profile-and-encryption-and-mult-files/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns:cenc="urn:mpeg:cenc:2013" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="PT2S" type="dynamic" publishTime="some_time" availabilityStartTime="some_time" minimumUpdatePeriod="PT5S" timeShiftBufferDepth="PT1800S">
   <Period id="0" start="PT0S">
-    <AdaptationSet id="0" contentType="audio" segmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" startWithSAP="1" segmentAlignment="true">
       <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="31323334-3536-3738-3930-313233343536"/>
       <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b">
         <cenc:pssh>AAAANHBzc2gBAAAAEHfv7MCyTQKs4zweUuL7SwAAAAExMjM0NTY3ODkwMTIzNDU2AAAAAA==</cenc:pssh>

--- a/packager/app/test/testdata/live-profile-and-encryption-and-non-dash-if-iop/output.mpd
+++ b/packager/app/test/testdata/live-profile-and-encryption-and-non-dash-if-iop/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns:cenc="urn:mpeg:cenc:2013" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="PT2S" type="dynamic" publishTime="some_time" availabilityStartTime="some_time" minimumUpdatePeriod="PT5S" timeShiftBufferDepth="PT1800S">
   <Period id="0" start="PT0S">
-    <AdaptationSet id="0" contentType="audio" segmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" startWithSAP="1" segmentAlignment="true">
       <Representation id="0" bandwidth="134304" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="31323334-3536-3738-3930-313233343536"/>

--- a/packager/app/test/testdata/live-profile-and-encryption/output.mpd
+++ b/packager/app/test/testdata/live-profile-and-encryption/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" xmlns:cenc="urn:mpeg:cenc:2013" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="PT2S" type="dynamic" publishTime="some_time" availabilityStartTime="some_time" minimumUpdatePeriod="PT5S" timeShiftBufferDepth="PT1800S">
   <Period id="0" start="PT0S">
-    <AdaptationSet id="0" contentType="audio" segmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" startWithSAP="1" segmentAlignment="true">
       <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="31323334-3536-3738-3930-313233343536"/>
       <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b">
         <cenc:pssh>AAAANHBzc2gBAAAAEHfv7MCyTQKs4zweUuL7SwAAAAExMjM0NTY3ODkwMTIzNDU2AAAAAA==</cenc:pssh>

--- a/packager/app/test/testdata/live-profile-and-key-rotation-and-no-pssh-in-stream/output.mpd
+++ b/packager/app/test/testdata/live-profile-and-key-rotation-and-no-pssh-in-stream/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="PT2S" type="dynamic" publishTime="some_time" availabilityStartTime="some_time" minimumUpdatePeriod="PT5S" timeShiftBufferDepth="PT1800S">
   <Period id="0" start="PT0S">
-    <AdaptationSet id="0" contentType="audio" segmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" startWithSAP="1" segmentAlignment="true">
       <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011"/>
       <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b"/>
       <Representation id="0" bandwidth="134880" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">

--- a/packager/app/test/testdata/live-profile-and-key-rotation-and-non-dash-if-iop/output.mpd
+++ b/packager/app/test/testdata/live-profile-and-key-rotation-and-non-dash-if-iop/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="PT2S" type="dynamic" publishTime="some_time" availabilityStartTime="some_time" minimumUpdatePeriod="PT5S" timeShiftBufferDepth="PT1800S">
   <Period id="0" start="PT0S">
-    <AdaptationSet id="0" contentType="audio" segmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" startWithSAP="1" segmentAlignment="true">
       <Representation id="0" bandwidth="135297" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011"/>

--- a/packager/app/test/testdata/live-profile-and-key-rotation-cbcs/output.mpd
+++ b/packager/app/test/testdata/live-profile-and-key-rotation-cbcs/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="PT2S" type="dynamic" publishTime="some_time" availabilityStartTime="some_time" minimumUpdatePeriod="PT5S" timeShiftBufferDepth="PT1800S">
   <Period id="0" start="PT0S">
-    <AdaptationSet id="0" contentType="audio" segmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" startWithSAP="1" segmentAlignment="true">
       <ContentProtection value="cbcs" schemeIdUri="urn:mpeg:dash:mp4protection:2011"/>
       <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b"/>
       <Representation id="0" bandwidth="134368" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">

--- a/packager/app/test/testdata/live-profile-and-key-rotation/output.mpd
+++ b/packager/app/test/testdata/live-profile-and-key-rotation/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="PT2S" type="dynamic" publishTime="some_time" availabilityStartTime="some_time" minimumUpdatePeriod="PT5S" timeShiftBufferDepth="PT1800S">
   <Period id="0" start="PT0S">
-    <AdaptationSet id="0" contentType="audio" segmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" startWithSAP="1" segmentAlignment="true">
       <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011"/>
       <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b"/>
       <Representation id="0" bandwidth="135297" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">

--- a/packager/app/test/testdata/live-profile/output.mpd
+++ b/packager/app/test/testdata/live-profile/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="PT2S" type="dynamic" publishTime="some_time" availabilityStartTime="some_time" minimumUpdatePeriod="PT5S" timeShiftBufferDepth="PT1800S">
   <Period id="0" start="PT0S">
-    <AdaptationSet id="0" contentType="audio" segmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" startWithSAP="1" segmentAlignment="true">
       <Representation id="0" bandwidth="133961" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <SegmentTemplate timescale="44100" initialization="bear-640x360-audio-init.mp4" media="bear-640x360-audio-$Number$.m4s" startNumber="1">

--- a/packager/app/test/testdata/live-static-profile-with-time-in-segment-name/output.mpd
+++ b/packager/app/test/testdata/live-static-profile-with-time-in-segment-name/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" segmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" startWithSAP="1" segmentAlignment="true">
       <Representation id="0" bandwidth="133961" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <SegmentTemplate timescale="44100" initialization="bear-640x360-audio-init.mp4" media="bear-640x360-audio-$Time$.m4s" startNumber="1">

--- a/packager/app/test/testdata/live-static-profile/output.mpd
+++ b/packager/app/test/testdata/live-static-profile/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" segmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" startWithSAP="1" segmentAlignment="true">
       <Representation id="0" bandwidth="133961" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <SegmentTemplate timescale="44100" initialization="bear-640x360-audio-init.mp4" media="bear-640x360-audio-$Number$.m4s" startNumber="1">

--- a/packager/app/test/testdata/mp4-trailing-moov/output.mpd
+++ b/packager/app/test/testdata/mp4-trailing-moov/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <Representation id="0" bandwidth="133334" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <BaseURL>bear-640x360-trailing-moov-audio.mp4</BaseURL>

--- a/packager/app/test/testdata/video-audio-ttml/output.mpd
+++ b/packager/app/test/testdata/video-audio-ttml/output.mpd
@@ -7,7 +7,7 @@
         <BaseURL>bear-english-text.ttml</BaseURL>
       </Representation>
     </AdaptationSet>
-    <AdaptationSet id="1" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="1" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <Representation id="0" bandwidth="133334" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <BaseURL>bear-640x360-audio.mp4</BaseURL>

--- a/packager/app/test/testdata/video-audio-webvtt/output.mpd
+++ b/packager/app/test/testdata/video-audio-webvtt/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0">
-    <AdaptationSet id="0" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <Representation id="0" bandwidth="133334" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <BaseURL>bear-640x360-audio.mp4</BaseURL>

--- a/packager/app/test/testdata/vtt-text-to-mp4-with-ad-cues/output.mpd
+++ b/packager/app/test/testdata/vtt-text-to-mp4-with-ad-cues/output.mpd
@@ -2,7 +2,7 @@
 <!--Generated with https://github.com/shaka-project/shaka-packager version <tag>-<hash>-<test>-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT2.736067S">
   <Period id="0" duration="PT2.002S">
-    <AdaptationSet id="0" contentType="audio" segmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" startWithSAP="1" segmentAlignment="true">
       <Representation id="0" bandwidth="133961" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <SegmentTemplate timescale="44100" initialization="bear-640x360-audio-init.mp4" media="bear-640x360-audio-$Number$.m4s" startNumber="1">
@@ -35,7 +35,7 @@
     </AdaptationSet>
   </Period>
   <Period id="1" duration="PT0.734067S">
-    <AdaptationSet id="0" contentType="audio" segmentAlignment="true">
+    <AdaptationSet id="0" contentType="audio" startWithSAP="1" segmentAlignment="true">
       <Representation id="0" bandwidth="108129" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <SegmentTemplate timescale="44100" presentationTimeOffset="88288" initialization="bear-640x360-audio-init.mp4" media="bear-640x360-audio-$Number$.m4s" startNumber="3">

--- a/packager/app/test/testdata/wvm-input-without-stripping-parameters-set-nalus/output.mpd
+++ b/packager/app/test/testdata/wvm-input-without-stripping-parameters-set-nalus/output.mpd
@@ -16,7 +16,7 @@
         </SegmentBase>
       </Representation>
     </AdaptationSet>
-    <AdaptationSet id="1" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="1" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <Representation id="1" bandwidth="131925" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <BaseURL>bear-multi-configs-1.mp4</BaseURL>

--- a/packager/app/test/testdata/wvm-input/output.mpd
+++ b/packager/app/test/testdata/wvm-input/output.mpd
@@ -16,7 +16,7 @@
         </SegmentBase>
       </Representation>
     </AdaptationSet>
-    <AdaptationSet id="1" contentType="audio" subsegmentAlignment="true">
+    <AdaptationSet id="1" contentType="audio" subsegmentStartsWithSAP="1" subsegmentAlignment="true">
       <Representation id="1" bandwidth="131925" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <BaseURL>bear-multi-configs-1.mp4</BaseURL>

--- a/packager/mpd/base/adaptation_set.cc
+++ b/packager/mpd/base/adaptation_set.cc
@@ -288,6 +288,14 @@ std::optional<xml::XmlNode> AdaptationSet::GetXml() {
       return std::nullopt;
     }
   }
+  if (subsegment_start_with_sap_ == 1) {
+    if (!adaptation_set.SetIntegerAttribute("subsegmentStartsWithSAP", 1))
+      return base::nullopt;
+  }
+  else if (start_with_sap_ == 1) {
+    if (!adaptation_set.SetIntegerAttribute("startWithSAP", 1))
+      return base::nullopt;
+  }
 
   if (video_frame_rates_.size() == 1) {
     suppress_representation_frame_rate = true;
@@ -412,6 +420,14 @@ void AdaptationSet::ForceSetSegmentAlignment(bool segment_alignment) {
 void AdaptationSet::AddAdaptationSetSwitching(
     const AdaptationSet* adaptation_set) {
   switchable_adaptation_sets_.push_back(adaptation_set);
+}
+
+void AdaptationSet::ForceSubsegmentStartswithSAP(uint32_t sap_value) {
+  subsegment_start_with_sap_ = sap_value;
+}
+
+void AdaptationSet::ForceStartwithSAP(uint32_t sap_value) {
+  start_with_sap_ = sap_value;
 }
 
 // For dynamic MPD, storing all start_time and duration will out-of-memory

--- a/packager/mpd/base/adaptation_set.cc
+++ b/packager/mpd/base/adaptation_set.cc
@@ -276,6 +276,7 @@ std::optional<xml::XmlNode> AdaptationSet::GetXml() {
       return std::nullopt;
     }
   }
+
   if (video_heights_.size() == 1) {
     suppress_representation_height = true;
     if (!adaptation_set.SetIntegerAttribute("height", *video_heights_.begin()))
@@ -286,11 +287,13 @@ std::optional<xml::XmlNode> AdaptationSet::GetXml() {
       return std::nullopt;
     }
   }
-  if (subsegment_start_with_sap_ == 1) {
-    if (!adaptation_set.SetIntegerAttribute("subsegmentStartsWithSAP", 1))
+
+  if (subsegment_start_with_sap_) {
+    if (!adaptation_set.SetIntegerAttribute("subsegmentStartsWithSAP",
+                                            subsegment_start_with_sap_))
       return std::nullopt;
-  } else if (start_with_sap_ == 1) {
-    if (!adaptation_set.SetIntegerAttribute("startWithSAP", 1))
+  } else if (start_with_sap_) {
+    if (!adaptation_set.SetIntegerAttribute("startWithSAP", start_with_sap_))
       return std::nullopt;
   }
 

--- a/packager/mpd/base/adaptation_set.cc
+++ b/packager/mpd/base/adaptation_set.cc
@@ -177,9 +177,7 @@ AdaptationSet::AdaptationSet(const std::string& language,
                              uint32_t* counter)
     : representation_counter_(counter),
       language_(language),
-      mpd_options_(mpd_options),
-      segments_aligned_(kSegmentAlignmentUnknown),
-      force_set_segment_alignment_(false) {
+      mpd_options_(mpd_options) {
   DCHECK(counter);
 }
 

--- a/packager/mpd/base/adaptation_set.cc
+++ b/packager/mpd/base/adaptation_set.cc
@@ -290,11 +290,11 @@ std::optional<xml::XmlNode> AdaptationSet::GetXml() {
   }
   if (subsegment_start_with_sap_ == 1) {
     if (!adaptation_set.SetIntegerAttribute("subsegmentStartsWithSAP", 1))
-      return base::nullopt;
+      return std::nullopt;
   }
   else if (start_with_sap_ == 1) {
     if (!adaptation_set.SetIntegerAttribute("startWithSAP", 1))
-      return base::nullopt;
+      return std::nullopt;
   }
 
   if (video_frame_rates_.size() == 1) {

--- a/packager/mpd/base/adaptation_set.cc
+++ b/packager/mpd/base/adaptation_set.cc
@@ -291,8 +291,7 @@ std::optional<xml::XmlNode> AdaptationSet::GetXml() {
   if (subsegment_start_with_sap_ == 1) {
     if (!adaptation_set.SetIntegerAttribute("subsegmentStartsWithSAP", 1))
       return std::nullopt;
-  }
-  else if (start_with_sap_ == 1) {
+  } else if (start_with_sap_ == 1) {
     if (!adaptation_set.SetIntegerAttribute("startWithSAP", 1))
       return std::nullopt;
   }

--- a/packager/mpd/base/adaptation_set.h
+++ b/packager/mpd/base/adaptation_set.h
@@ -118,6 +118,17 @@ class AdaptationSet {
   ///        attribute.
   virtual void ForceSetSegmentAlignment(bool segment_alignment);
 
+  /// Forces the subsegmentStartswithSAP field to be set to @a sap_value.
+  /// Use this if you are certain with stream access point value of the
+  /// subsegment.
+  /// @param sap_value is the value used for subsegmentstartsWithSAP attribute.
+  virtual void ForceSubsegmentStartswithSAP(uint32_t sap_value);
+
+  /// Forces the StartswithSAP field to be set to @a sap_value.
+  /// Use this if you are certain with stream access point value of the segment.
+  /// @param sap_value is the value used for  startWithSAP attribute.
+  virtual void ForceStartwithSAP(uint32_t sap_value);
+
   /// Adds the adaptation set this adaptation set can switch to.
   /// @param adaptation_set points to the switchable adaptation set.
   virtual void AddAdaptationSetSwitching(const AdaptationSet* adaptation_set);
@@ -310,6 +321,12 @@ class AdaptationSet {
   // True iff all the segments are aligned.
   SegmentAligmentStatus segments_aligned_;
   bool force_set_segment_alignment_;
+
+  // The stream access point for subsegment
+  uint8_t subsegment_start_with_sap_;
+
+  // The stream access point for segment
+  uint8_t start_with_sap_;
 
   // Keeps track of segment start times of Representations.
   // For static MPD, this will not be cleared, all the segment start times are

--- a/packager/mpd/base/adaptation_set.h
+++ b/packager/mpd/base/adaptation_set.h
@@ -319,14 +319,14 @@ class AdaptationSet {
   std::set<Role> roles_;
 
   // True iff all the segments are aligned.
-  SegmentAligmentStatus segments_aligned_;
-  bool force_set_segment_alignment_;
+  SegmentAligmentStatus segments_aligned_ = kSegmentAlignmentUnknown;
+  bool force_set_segment_alignment_ = false;
 
   // The stream access point for subsegment
-  uint8_t subsegment_start_with_sap_;
+  uint8_t subsegment_start_with_sap_ = 0;
 
   // The stream access point for segment
-  uint8_t start_with_sap_;
+  uint8_t start_with_sap_ = 0;
 
   // Keeps track of segment start times of Representations.
   // For static MPD, this will not be cleared, all the segment start times are

--- a/packager/mpd/base/period.cc
+++ b/packager/mpd/base/period.cc
@@ -298,6 +298,26 @@ bool Period::SetNewAdaptationSetAttributes(
     // In practice it doesn't really make sense to adapt between text tracks.
     new_adaptation_set->ForceSetSegmentAlignment(true);
   }
+
+  if (mpd_options_.dash_profile == DashProfile::kLive) {
+    // According to Dolby Digital Plus and Dolby AC-4 specs, startWithSAP
+    // attribute shall be set to 1. Other audio codecs do not have
+    // requirement on this value, we assume them to be 1 as well.
+    if (GetBaseCodec(media_info) == "mp4a" ||
+        GetBaseCodec(media_info) == "ac-3" ||
+        GetBaseCodec(media_info) == "ec-3" ||
+        GetBaseCodec(media_info) == "ac-4") {
+      new_adaptation_set->ForceStartwithSAP(1);
+    }
+  }
+  else if (mpd_options_.dash_profile == DashProfile::kOnDemand) {
+    if (GetBaseCodec(media_info) == "mp4a" ||
+        GetBaseCodec(media_info) == "ac-3" ||
+        GetBaseCodec(media_info) == "ec-3" ||
+        GetBaseCodec(media_info) == "ac-4") {
+      new_adaptation_set->ForceSubsegmentStartswithSAP(1);
+    }
+  }
   return true;
 }
 

--- a/packager/mpd/base/period.cc
+++ b/packager/mpd/base/period.cc
@@ -309,8 +309,7 @@ bool Period::SetNewAdaptationSetAttributes(
         GetBaseCodec(media_info) == "ac-4") {
       new_adaptation_set->ForceStartwithSAP(1);
     }
-  }
-  else if (mpd_options_.dash_profile == DashProfile::kOnDemand) {
+  } else if (mpd_options_.dash_profile == DashProfile::kOnDemand) {
     if (GetBaseCodec(media_info) == "mp4a" ||
         GetBaseCodec(media_info) == "ac-3" ||
         GetBaseCodec(media_info) == "ec-3" ||

--- a/packager/mpd/base/period_unittest.cc
+++ b/packager/mpd/base/period_unittest.cc
@@ -588,8 +588,8 @@ TEST_F(PeriodTest, OrderedByAdaptationSetId) {
       R"(<Period id="9">)"
       // ContentType and Representation elements are populated after
       // Representation::Init() is called.
-      R"(  <AdaptationSet id="0" contentType=""/>)"
-      R"(  <AdaptationSet id="1" contentType=""/>)"
+      R"(  <AdaptationSet id="0" contentType="" subsegmentStartsWithSAP="1"/>)"
+      R"(  <AdaptationSet id="1" contentType="" subsegmentStartsWithSAP="1"/>)"
       R"(</Period>)";
   EXPECT_THAT(testable_period_.GetXml(!kOutputPeriodDuration),
               XmlNodeEqual(kExpectedXml));

--- a/packager/mpd/test/data/audio_media_info1_video_media_info1_expected_mpd_output.txt
+++ b/packager/mpd/test/data/audio_media_info1_video_media_info1_expected_mpd_output.txt
@@ -9,7 +9,7 @@
         </SegmentBase>
       </Representation>
     </AdaptationSet>
-    <AdaptationSet contentType="audio" id="1">
+    <AdaptationSet contentType="audio" subsegmentStartsWithSAP="1" id="1">
       <Representation id="1" bandwidth="400" codecs="mp4a.40.2" mimeType="audio/mp4" audioSamplingRate="44100">
         <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         <BaseURL>test_output_file_name_audio1.mp4</BaseURL>


### PR DESCRIPTION
Replaces #1055

This pull request adds startwithSAP/subsegmentstartswithSAP for aac, ac3, ec3 and ac4 audio tracks according to LIVE or VOD profile.

Closes #364