### PR TITLE
fix: http_file: Close upload cache on task exit

### DIFF
--- a/packager/file/http_file.cc
+++ b/packager/file/http_file.cc
@@ -372,6 +372,12 @@ void HttpFile::ThreadMain() {
         error_message);
   }
 
+  // In some cases it is possible that the server has already closed the
+  // connection without reading the request body. This can for example happen
+  // when the server responds with a non-successful status code. In this case we
+  // need to make sure to close the upload cache here, otherwise some other
+  // thread may block forever on Flush().
+  upload_cache_.Close();
   download_cache_.Close();
   task_exit_event_.Notify();
 }


### PR DESCRIPTION
In some cases it can happen that the http server responds with a non-successful status code without reading the response body. In this case curl may decide not to read from the cache since there is really no point in sending data to the server. In case some other thread of shaka has already called HttpFile::Flush it may end up deadlocked there waiting for the cache to either close or become empty. Thus, we close the cache when leaving the main thread as no data will be read by curl after it has finished anyways.

Closes #1347