### PR TITLE
fix: Always log to stderr by default

### DIFF
--- a/packager/app/mpd_generator.cc
+++ b/packager/app/mpd_generator.cc
@@ -31,6 +31,9 @@ ABSL_FLAG(std::string,
           "",
           "Packager version for testing. Should be used for testing only.");
 
+// From absl/log:
+ABSL_DECLARE_FLAG(int, stderrthreshold);
+
 namespace shaka {
 namespace {
 const char kUsage[] =
@@ -109,6 +112,13 @@ int MpdMain(int argc, char** argv) {
 
   auto usage = absl::StrFormat(kUsage, argv[0]);
   absl::SetProgramUsageMessage(usage);
+
+  // Before parsing the command line, change the default value of some flags
+  // provided by libraries.
+
+  // Always log to stderr.  Log levels are still controlled by --minloglevel.
+  absl::SetFlag(&FLAGS_stderrthreshold, 0);
+
   absl::ParseCommandLine(argc, argv);
 
   if (absl::GetFlag(FLAGS_licenses)) {

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -58,6 +58,9 @@ ABSL_FLAG(bool,
           false,
           "If enabled, only use one thread when generating content.");
 
+// From absl/log:
+ABSL_DECLARE_FLAG(int, stderrthreshold);
+
 namespace shaka {
 namespace {
 
@@ -555,6 +558,12 @@ int PackagerMain(int argc, char** argv) {
 
   auto usage = absl::StrFormat(kUsage, argv[0]);
   absl::SetProgramUsageMessage(usage);
+
+  // Before parsing the command line, change the default value of some flags
+  // provided by libraries.
+
+  // Always log to stderr.  Log levels are still controlled by --minloglevel.
+  absl::SetFlag(&FLAGS_stderrthreshold, 0);
 
   auto remaining_args = absl::ParseCommandLine(argc, argv);
   if (absl::GetFlag(FLAGS_licenses)) {


### PR DESCRIPTION
This tweaks the default config for stderrthreshold from absl/log so that we always get logs to stderr by default, as we did in v2.  The --quiet and --v flags that existed in v2 can still be used to modify the log level, as well as the new --minloglevel from absl/log.

Issue #1325