### PR TITLE
fix: Fix missing newline at the end of usage

### DIFF
--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -129,7 +129,7 @@ const char kUsage[] =
     "    used to caption short portions of the audio that might be in a \n"
     "    foreign language. For DASH this will set role to forced_subtitle, \n"
     "    for HLS it will set FORCED=YES and AUTOSELECT=YES. \n"
-    "    Only valid for subtitles.";
+    "    Only valid for subtitles.\n";
 
 // Labels for parameters in RawKey key info.
 const char kDrmLabelLabel[] = "label";


### PR DESCRIPTION
Without this, the command prompt will not appear on its own line after running `packager` with no arguments.