### PR TITLE
fix(CI): Add Mac-arm64 to build matrix

### DIFF
--- a/.github/workflows/build-matrix.json
+++ b/.github/workflows/build-matrix.json
@@ -9,9 +9,18 @@
       "generator": "Ninja"
     },
     {
-      "os": "macos-latest",
+      "comment": "Explicit macOS versions are required for explicit x64 CPU.",
+      "os": "macos-14",
       "os_name": "osx",
       "target_arch": "x64",
+      "exe_ext": "",
+      "generator": "Ninja"
+    },
+    {
+      "comment": "Explicit macOS versions are required for explicit arm64 CPU.",
+      "os": "macos-14-arm64",
+      "os_name": "osx",
+      "target_arch": "arm64",
       "exe_ext": "",
       "generator": "Ninja"
     },

--- a/.github/workflows/build-matrix.json
+++ b/.github/workflows/build-matrix.json
@@ -9,16 +9,16 @@
       "generator": "Ninja"
     },
     {
-      "comment": "Explicit macOS versions are required for explicit x64 CPU.",
-      "os": "macos-14",
+      "comment": "Explicit macOS version 13 is required for explicit x64 CPU.",
+      "os": "macos-13",
       "os_name": "osx",
       "target_arch": "x64",
       "exe_ext": "",
       "generator": "Ninja"
     },
     {
-      "comment": "Explicit macOS versions are required for explicit arm64 CPU.",
-      "os": "macos-14-arm64",
+      "comment": "Explicit macOS version 14 is required for explicit arm64 CPU.",
+      "os": "macos-14",
       "os_name": "osx",
       "target_arch": "arm64",
       "exe_ext": "",

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -139,6 +139,8 @@ jobs:
           fi
 
           LABEL=$(uname -m)
+          echo "Hardware label: \"$LABEL\""
+
           if [[ "$LABEL" != "$CORRECT_LABEL" ]]; then
             echo "Wrong hardware label \"$LABEL\", expecting \"$CORRECT_LABEL\"."
             echo "Full uname string: $(uname -a)"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -127,6 +127,26 @@ jobs:
         run: |
           brew install ninja
 
+      - name: Check Mac CPU architecture
+        if: runner.os == 'macOS'
+        # In case we get confused about GitHub's mac VM image labels,
+        # explicitly check that the CPU type matches our expectations.
+        run: |
+          if [[ "${{matrix.target_arch}}" == "arm64" ]]; then
+            CORRECT_LABEL="arm64"
+          else
+            CORRECT_LABEL="x86_64"
+          fi
+
+          LABEL=$(uname -m)
+          if [[ "$LABEL" != "$CORRECT_LABEL" ]]; then
+            echo "Wrong hardware label \"$LABEL\", expecting \"$CORRECT_LABEL\"."
+            echo "Full uname string: $(uname -a)"
+            echo "Full sysctl CPU info:"
+            sysctl machdep.cpu
+            exit 1
+          fi
+
       - name: Generate build files
         run: |
           mkdir -p build/


### PR DESCRIPTION
Support for this came out in January, 2024.  Explicit macos versions seem to be necessary for now, until GitHub offers "latest" labels targeting specific architectures.