### PR TITLE
fix: Fix tags in official Docker images and binaries

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -96,6 +96,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           submodules: recursive
+          fetch-tags: true
 
       - name: Install Linux deps
         if: runner.os == 'Linux'

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -47,6 +47,7 @@ jobs:
         with:
           ref: ${{ inputs.tag }}
           submodules: recursive
+          fetch-tags: true
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -57,6 +58,11 @@ jobs:
       - name: Push to Docker Hub
         uses: docker/build-push-action@v5
         with:
+          # Important: use actions/checkout source, which has the right tags!
+          # Without context: ., this action will try to fetch git source
+          # itself, and it will be unable to determine the correct version
+          # number.
+          context: .
           push: true
           tags: ${{ secrets.DOCKERHUB_PACKAGE_NAME }}:${{ inputs.tag }}
 
@@ -64,5 +70,10 @@ jobs:
         if: ${{ inputs.latest }}
         uses: docker/build-push-action@v5
         with:
+          # Important: use actions/checkout source, which has the right tags!
+          # Without context: ., this action will try to fetch git source
+          # itself, and it will be unable to determine the correct version
+          # number.
+          context: .
           push: true
           tags: ${{ secrets.DOCKERHUB_PACKAGE_NAME }}:latest

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -55,7 +55,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-tags: true
-          persist-credentials: false
 
       - name: Compute latest
         id: compute

--- a/packager/version/generate_version_string.py
+++ b/packager/version/generate_version_string.py
@@ -8,23 +8,37 @@
 """This script is used to generate version string for packager."""
 
 import subprocess
+import sys
 
 if __name__ == '__main__':
   try:
     version_tag = subprocess.check_output('git tag --points-at HEAD',
         stderr=subprocess.STDOUT, shell=True).decode().rstrip()
+    if version_tag:
+      print('Found version tag: {}'.format(version_tag), file=sys.stderr)
+    else:
+      print('Cannot find version tag!', file=sys.stderr)
   except subprocess.CalledProcessError as e:
     # git tag --points-at is not supported in old versions of git. Just ignore
     # version_tag in this case.
     version_tag = None
+    print('Old version of git, cannot determine version tag!', file=sys.stderr)
 
   try:
     version_hash = subprocess.check_output('git rev-parse --short HEAD',
         stderr=subprocess.STDOUT, shell=True).decode().rstrip()
+    print('Version hash: {}'.format(version_hash), file=sys.stderr)
   except subprocess.CalledProcessError as e:
     version_hash = 'unknown-version'
+    print('Cannot find version hasah!', file=sys.stderr)
 
   if version_tag:
-    print('{0}-{1}'.format(version_tag, version_hash))
+    output = '{0}-{1}'.format(version_tag, version_hash)
   else:
-    print(version_hash)
+    output = version_hash
+
+  # Final debug message, mirroring what is used to generate the source file:
+  print('Final output: {}'.format(output), file=sys.stderr)
+
+  # Actually used to generate the source file:
+  print(output)


### PR DESCRIPTION
The release workflows did not run checkout with `fetch-tags: true`, so the builds were unable to compute the correct release version number. I audited all instances of `actions/checkout` to add `fetch-tags` where needed and clean up unneeded options.

I also had to fix options to `docker/build-push-action`, which by default ignores `actions/checkout` and tries to pull from git itself.  This led to the Docker build running in a context without the new tag.

Finally, to make verification easier and provide version info in the build logs, this adds debugging info to the version-generation script via stderr.

Closes #1366