### PR TITLE
fix: Fix NPM binary publication

### DIFF
--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -44,7 +44,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag }}
-          submodules: recursive
 
       - uses: actions/setup-node@v4
         with:

--- a/npm/.npmignore
+++ b/npm/.npmignore
@@ -1,0 +1,8 @@
+# This file is required for us, even if empty.
+#
+# The default .npmignore would disallow bin/, which contains binaries for our
+# NPM release.  Every release before v3.0.3 was missing .npmignore, and
+# therefore had no binaries.  These were unusable in NPM, and have been marked
+# as deprecated because of it.
+#
+# See also https://github.com/shaka-project/shaka-packager/issues/1369

--- a/npm/prepublish.js
+++ b/npm/prepublish.js
@@ -14,6 +14,7 @@ var commandNames = {
   },
   darwin: {
     'x64': 'packager-osx-x64',
+    'arm64': 'packager-osx-arm64',
   },
   win32: {
     'x64': 'packager-win-x64.exe',


### PR DESCRIPTION
The default .npmignore would disallow bin/, which contains binaries for our NPM release.  Every release before v3.0.3 was missing .npmignore, and therefore had no binaries.  These were unusable in NPM, and have been marked as deprecated because of it.

Closes #1369