### PR TITLE
fix: escape media URLs in MPD

### DIFF
--- a/packager/mpd/CMakeLists.txt
+++ b/packager/mpd/CMakeLists.txt
@@ -51,6 +51,7 @@ target_link_libraries(mpd_builder
   media_base
   mpd_media_info_proto
   utils_clock
+  libcurl
 )
 
 

--- a/packager/mpd/base/mpd_builder.cc
+++ b/packager/mpd/base/mpd_builder.cc
@@ -167,7 +167,7 @@ std::optional<xml::XmlNode> MpdBuilder::GenerateMpd() {
   // Add baseurls to MPD.
   for (const std::string& base_url : base_urls_) {
     XmlNode xml_base_url("BaseURL");
-    xml_base_url.SetContent(base_url);
+    xml_base_url.SetUrlEncodedContent(base_url);
 
     if (!mpd.AddChild(std::move(xml_base_url)))
       return std::nullopt;

--- a/packager/mpd/base/xml/xml_node.cc
+++ b/packager/mpd/base/xml/xml_node.cc
@@ -60,7 +60,7 @@ std::string urlEncode(const std::string& input) {
   char* output = curl_easy_escape(curl, input.c_str(), input.length());
   if (output) {
     std::string encodedUrl(output);
-    curl_free(output);        // Free the output string when done
+    curl_free(output);  // Free the output string when done
     return encodedUrl;
   }
   return "";  // Return empty string if initialization fails

--- a/packager/mpd/base/xml/xml_node.cc
+++ b/packager/mpd/base/xml/xml_node.cc
@@ -55,17 +55,13 @@ const char kDTSECodec[] = "dtse";
 const char kDTSXCodec[] = "dtsx";
 
 std::string urlEncode(const std::string& input) {
-  CURL* curl = curl_easy_init();  // Initialize a CURL session
-  if (curl) {
-    char* output = curl_easy_escape(curl, input.c_str(), input.length());
-    if (output) {
-      std::string encodedUrl(output);
-      curl_free(output);        // Free the output string when done
-      curl_easy_cleanup(curl);  // Clean up the CURL session
-      return encodedUrl;
-    }
-    curl_easy_cleanup(
-        curl);  // Clean up the CURL session even if encoding fails
+  // NOTE: According to the docs, "Since 7.82.0, the curl parameter is ignored".
+  CURL* curl = NULL;
+  char* output = curl_easy_escape(curl, input.c_str(), input.length());
+  if (output) {
+    std::string encodedUrl(output);
+    curl_free(output);        // Free the output string when done
+    return encodedUrl;
   }
   return "";  // Return empty string if initialization fails
 }

--- a/packager/mpd/base/xml/xml_node.h
+++ b/packager/mpd/base/xml/xml_node.h
@@ -83,6 +83,8 @@ class XmlNode {
   /// Similar to SetContent, but appends to the end of existing content.
   void AddContent(const std::string& content);
 
+  void AddUrlEncodedContent(const std::string& content);
+
   /// Set the contents of an XML element using a string.
   /// This cannot set child elements because <> will become &lt; and &rt;
   /// This should be used to set the text for the element, e.g. setting
@@ -90,6 +92,8 @@ class XmlNode {
   /// @param content is a string containing the text-encoded child elements to
   ///        be added to the element.
   void SetContent(const std::string& content);
+
+  void SetUrlEncodedContent(const std::string& content);
 
   /// @return namespaces used in the node and its descendents.
   std::set<std::string> ExtractReferencedNamespaces() const;


### PR DESCRIPTION
Currently `media_info.media_file_url()` is not escaped when placed into MPD for things like BaseURL. This for example breaks when trying to us a file name that contains special characters like &. Since these are supposed to be URLs let's URL encode them.

Fixes #1107