### PR TITLE
fix: set yuv full range flag to 1 for VP9 with sRGB

### DIFF
--- a/packager/media/codecs/vp9_parser.cc
+++ b/packager/media/codecs/vp9_parser.cc
@@ -285,7 +285,7 @@ bool ReadBitDepthAndColorSpace(BitReader* reader,
     }
   } else {
     // Assume 4:4:4 for colorspace SRGB.
-    yuv_full_range = 1;
+    yuv_full_range = true;
     chroma_subsampling = VPCodecConfigurationRecord::CHROMA_444;
     if (codec_config->profile() & 1) {
       bool reserved;

--- a/packager/media/codecs/vp9_parser.cc
+++ b/packager/media/codecs/vp9_parser.cc
@@ -285,6 +285,7 @@ bool ReadBitDepthAndColorSpace(BitReader* reader,
     }
   } else {
     // Assume 4:4:4 for colorspace SRGB.
+    yuv_full_range = 1;
     chroma_subsampling = VPCodecConfigurationRecord::CHROMA_444;
     if (codec_config->profile() & 1) {
       bool reserved;


### PR DESCRIPTION
If color_space is VPX_COLOR_SPACE_SRGB, the specs says that color_range should be 1 i.e. yuv_full_range = true. However, yuv_full_range is default initialized as false and isn't set in the branch for color_space is VPX_COLOR_SPACE_SRGB.

Fixes #990