### PR TITLE
docs: document --enable_entitlement_license option for Widevine

### DIFF
--- a/docs/source/options/widevine_encryption_options.rst
+++ b/docs/source/options/widevine_encryption_options.rst
@@ -9,6 +9,10 @@ Widevine encryption options
     --protection_systems is not specified. Use --protection_systems to generate
     multiple protection systems.
 
+--enable_entitlement_license
+
+    Enable entitlement license in the Widevine encryption request.
+
 --enable_widevine_decryption
 
     Enable decryption with Widevine key server. User should provide either


### PR DESCRIPTION
The option was never covered to the widevine docs when it was added, requiring someone to read the source code or the --help to discover this option.

Fixes #983