### PR TITLE
fix: Add Missing Dash Roles to RoleFromString function (#1418)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -39,4 +39,5 @@ Richard Eklycke <richard@eklycke.se>
 Sanil Raut <sr1990003@gmail.com>
 Sergio Ammirata <sergio@ammirata.net>
 The Chromium Authors <*@chromium.org>
+Sveriges Television AB <*@svt.se>
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -57,4 +57,5 @@ Tim Lansen <tim.lansen@gmail.com>
 Torbjörn Einarsson <torbjorn.einarsson@eyevinn.se>
 Vincent Nguyen <nvincen@amazon.com>
 Weiguo Shao <weiguo.shao@dolby.com>
+John Laurin <john.laurin@svt.se>
 

--- a/packager/mpd/base/period.cc
+++ b/packager/mpd/base/period.cc
@@ -55,7 +55,7 @@ AdaptationSet::Role RoleFromString(const std::string& role_str) {
   if (role_str == "emergency")
     return AdaptationSet::Role::kRoleEmergency;
   if (role_str == "easyreader")
-    return AdaptationSet::Role::kRoleEasyreader;                
+    return AdaptationSet::Role::kRoleEasyreader;
   if (role_str == "description")
     return AdaptationSet::Role::kRoleDescription;
   return AdaptationSet::Role::kRoleUnknown;

--- a/packager/mpd/base/period.cc
+++ b/packager/mpd/base/period.cc
@@ -44,6 +44,18 @@ AdaptationSet::Role RoleFromString(const std::string& role_str) {
     return AdaptationSet::Role::kRoleDub;
   if (role_str == "forced-subtitle")
     return AdaptationSet::Role::kRoleForcedSubtitle;
+  if (role_str == "karaoke")
+    return AdaptationSet::Role::kRoleKaraoke;
+  if (role_str == "sign")
+    return AdaptationSet::Role::kRoleSign;
+  if (role_str == "metadata")
+    return AdaptationSet::Role::kRoleMetadata;
+  if (role_str == "enhanced-audio-intelligibility")
+    return AdaptationSet::Role::kRoleEnhancedAudioIntelligibility;
+  if (role_str == "emergency")
+    return AdaptationSet::Role::kRoleEmergency;
+  if (role_str == "easyreader")
+    return AdaptationSet::Role::kRoleEasyreader;                
   if (role_str == "description")
     return AdaptationSet::Role::kRoleDescription;
   return AdaptationSet::Role::kRoleUnknown;


### PR DESCRIPTION
As per issue #1418, several Dash roles are missing from the RoleFromString function, making them unusable in practice. This update should enable them for use.