### PR TITLE
fix: Embed full python protobuf library

### DIFF
--- a/packager/third_party/protobuf/CMakeLists.txt
+++ b/packager/third_party/protobuf/CMakeLists.txt
@@ -30,3 +30,6 @@ add_definitions(-DNDEBUG)
 
 # With these set in scope of this folder, load the library's own CMakeLists.txt.
 add_subdirectory(source)
+
+# Build generated python sources for the protobuf library.
+include("protobuf_py.cmake")

--- a/packager/third_party/protobuf/protobuf_py.cmake
+++ b/packager/third_party/protobuf/protobuf_py.cmake
@@ -1,0 +1,63 @@
+# Copyright 2022 Google LLC. All rights reserved.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file or at
+# https://developers.google.com/open-source/licenses/bsd
+
+# Build generated python sources for the protobuf library.
+set(protobuf_py_proto_path ${CMAKE_CURRENT_SOURCE_DIR}/source/src)
+set(protobuf_py_library_path ${CMAKE_CURRENT_SOURCE_DIR}/source/python)
+set(protobuf_py_output_path ${CMAKE_CURRENT_BINARY_DIR}/py)
+
+# Copy the library without the generated sources.
+add_custom_command(
+    DEPENDS
+        ${protobuf_py_proto_path}
+    OUTPUT
+        ${protobuf_py_output_path}/google
+    COMMAND
+        ${CMAKE_COMMAND} -E copy_directory
+        ${CMAKE_CURRENT_SOURCE_DIR}/source/python/google
+        ${protobuf_py_output_path}/google)
+
+# This list was taken from packager/third_party/protobuf/source/python/setup.py
+set(protobuf_py_filenames
+    google/protobuf/descriptor
+    google/protobuf/compiler/plugin
+    google/protobuf/any
+    google/protobuf/api
+    google/protobuf/duration
+    google/protobuf/empty
+    google/protobuf/field_mask
+    google/protobuf/source_context
+    google/protobuf/struct
+    google/protobuf/timestamp
+    google/protobuf/type
+    google/protobuf/wrappers)
+
+# For each proto in the list, generate a _pb2.py file to add to the library.
+set(protobuf_py_outputs "")
+foreach (filename ${protobuf_py_filenames})
+    set(proto_path "${protobuf_py_proto_path}/${filename}.proto")
+    set(output_path "${protobuf_py_output_path}/${filename}_pb2.py")
+
+    list(APPEND protobuf_py_outputs "${output_path}")
+
+    add_custom_command(
+        DEPENDS
+            protoc
+            ${proto_path}
+            ${protobuf_py_output_path}/google
+        OUTPUT
+            ${output_path}
+        COMMAND
+            protoc
+        ARGS
+            -I${protobuf_py_proto_path}
+            --python_out=${protobuf_py_output_path}
+            ${proto_path})
+endforeach ()
+
+# The entire python protobuf library (repo source and generated) to the output
+# folder.
+add_custom_target(protobuf_py ALL DEPENDS ${protobuf_py_outputs})

--- a/packager/tools/pssh/CMakeLists.txt
+++ b/packager/tools/pssh/CMakeLists.txt
@@ -14,6 +14,7 @@ set(PSSH_BOX_OUTPUTS
 
 add_custom_command(
     DEPENDS
+        protobuf_py
         widevine_protos
         pssh-box.py
     OUTPUT ${PSSH_BOX_OUTPUTS}
@@ -25,6 +26,10 @@ add_custom_command(
         ${CMAKE_BINARY_DIR}/packager/media/base/widevine_common_encryption_pb2.py
         ${CMAKE_BINARY_DIR}/packager/media/base/widevine_pssh_data_pb2.py
         ${CMAKE_BINARY_DIR}/packager/pssh-box-protos/
+    COMMAND
+        ${CMAKE_COMMAND} -E copy_directory
+        ${CMAKE_BINARY_DIR}/packager/third_party/protobuf/py/google
+        ${CMAKE_BINARY_DIR}/packager/pssh-box-protos/google
     COMMAND
         ${CMAKE_COMMAND} -E copy
         ${CMAKE_CURRENT_SOURCE_DIR}/pssh-box.py

--- a/packager/tools/pssh/pssh-box.py
+++ b/packager/tools/pssh/pssh-box.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Copyright 2016 Google LLC. All rights reserved.
 #
 # Use of this source code is governed by a BSD-style
@@ -10,8 +10,6 @@
 # This file itself is considered an invalid module name because of the dash in
 # the filename: pssh-box.py
 # pylint: disable=invalid-name
-
-from __future__ import print_function
 
 import argparse
 import base64


### PR DESCRIPTION
This embeds the full python protobuf library into the output in pssh-box-protos, which is used by installation targets and Docker images.  Without this, the installed pssh-box.py tool would depend on a separate installation of the python protobuf library.

Closes #1436