### PR TITLE
fix(http): Fix "Failed sending data to the peer" errors

### DIFF
--- a/packager/file/http_file.cc
+++ b/packager/file/http_file.cc
@@ -311,7 +311,7 @@ void HttpFile::SetupRequest() {
       curl_easy_setopt(curl, CURLOPT_POST, 1L);
       break;
     case HttpMethod::kPut:
-      curl_easy_setopt(curl, CURLOPT_PUT, 1L);
+      curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
       break;
   }
 

--- a/packager/third_party/curl/CMakeLists.txt
+++ b/packager/third_party/curl/CMakeLists.txt
@@ -45,5 +45,5 @@ add_subdirectory(source)
 # Our enabling of c-ares doesn't automatically set a dependency between libcurl
 # and c-ares.  Fix that now.
 if(USE_ARES)
-  target_link_libraries(libcurl c-ares)
+  target_link_libraries(libcurl_static PUBLIC c-ares)
 endif()


### PR DESCRIPTION
Upgrading curl fixes errors like "Failed sending data to the peer" flooding the log.  This is described upstream in https://github.com/curl/curl/issues/10591 and fixed in curl 8.2.0.  Here we upgrade to curl 8.9.1 (latest as of today).

This required updating the way we attach c-ares to libcurl and updating CURLOPT_PUT (deprecated) to CURLOPT_UPLOAD (compatible equivalent AFAICT).