### PR TITLE
ci: Ignore cert error for apt.kitware.com

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -105,16 +105,16 @@ jobs:
         # that may be greater than what is available in Ubuntu, so we set up
         # the official CMake PPA first.
         run: |
-          kitware_key_url="https://apt.kitware.com/keys/kitware-archive-latest.asc"
+          kitware_key_url="http://apt.kitware.com/keys/kitware-archive-latest.asc"
           kitware_key_path="/usr/share/keyrings/kitware-archive-keyring.gpg"
           kitware_sources_path="/etc/apt/sources.list.d/kitware.list"
 
-          curl -sLk "$kitware_key_url" | gpg --dearmor - \
+          curl -sL "$kitware_key_url" | gpg --dearmor - \
               | sudo tee "$kitware_key_path" >/dev/null
 
           . /etc/lsb-release  # Defines $DISTRIB_CODENAME (jammy, focal, etc)
 
-          echo "deb [signed-by=$kitware_key_path] https://apt.kitware.com/ubuntu/ $DISTRIB_CODENAME main" \
+          echo "deb [signed-by=$kitware_key_path] http://apt.kitware.com/ubuntu/ $DISTRIB_CODENAME main" \
               | sudo tee "$kitware_sources_path" >/dev/null
 
           sudo apt update

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -109,7 +109,7 @@ jobs:
           kitware_key_path="/usr/share/keyrings/kitware-archive-keyring.gpg"
           kitware_sources_path="/etc/apt/sources.list.d/kitware.list"
 
-          curl -sL "$kitware_key_url" | gpg --dearmor - \
+          curl -sLk "$kitware_key_url" | gpg --dearmor - \
               | sudo tee "$kitware_key_path" >/dev/null
 
           . /etc/lsb-release  # Defines $DISTRIB_CODENAME (jammy, focal, etc)

--- a/packager/testing/dockers/Ubuntu_Dockerfile
+++ b/packager/testing/dockers/Ubuntu_Dockerfile
@@ -15,7 +15,7 @@ ENV kitware_key_path /usr/share/keyrings/kitware-archive-keyring.gpg
 ENV kitware_sources_path /etc/apt/sources.list.d/kitware.list
 ENV DISTRIB_CODENAME jammy
 
-RUN wget -O - "$kitware_key_url" 2>/dev/null | gpg --dearmor - > "$kitware_key_path"
+RUN curl -sLk "$kitware_key_url" 2>/dev/null | gpg --dearmor - > "$kitware_key_path"
 RUN echo "deb [signed-by=$kitware_key_path] https://apt.kitware.com/ubuntu/ $DISTRIB_CODENAME main" > "$kitware_sources_path"
 
 RUN apt-get update && apt-get install -y cmake

--- a/packager/testing/dockers/Ubuntu_Dockerfile
+++ b/packager/testing/dockers/Ubuntu_Dockerfile
@@ -10,13 +10,13 @@ RUN apt-get install -y \
         build-essential git ninja-build python3 wget
 
 # Install the official CMake repo to get CMake v3.24+:
-ENV kitware_key_url https://apt.kitware.com/keys/kitware-archive-latest.asc
+ENV kitware_key_url http://apt.kitware.com/keys/kitware-archive-latest.asc
 ENV kitware_key_path /usr/share/keyrings/kitware-archive-keyring.gpg
 ENV kitware_sources_path /etc/apt/sources.list.d/kitware.list
 ENV DISTRIB_CODENAME jammy
 
 RUN curl -sLk "$kitware_key_url" 2>/dev/null | gpg --dearmor - > "$kitware_key_path"
-RUN echo "deb [signed-by=$kitware_key_path] https://apt.kitware.com/ubuntu/ $DISTRIB_CODENAME main" > "$kitware_sources_path"
+RUN echo "deb [signed-by=$kitware_key_path] http://apt.kitware.com/ubuntu/ $DISTRIB_CODENAME main" > "$kitware_sources_path"
 
 RUN apt-get update && apt-get install -y cmake
 


### PR DESCRIPTION
This should fix the retrieval of the GPG key and allow an updated cmake to be installed.