### PR TITLE
ci: Update workflow permissions

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -83,6 +83,10 @@ jobs:
     uses: ./.github/workflows/publish-docs.yaml
     with:
       ref: refs/tags/${{ needs.release.outputs.tag_name }}
+    # Required permissions to deploy to GitHub Pages:
+    permissions:
+      pages: write
+      id-token: write
 
   # Publish official docker image
   docker:


### PR DESCRIPTION
Now that default permissions are read-only, we must enable specific permissions for certain workflow jobs.