### PR TITLE
ci: Do not persist credentials after checkout

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -31,6 +31,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           submodules: recursive
+          persist-credentials: false
 
       - name: Build
         shell: bash

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
 
       - name: Generate docs
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,6 +47,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
 
       - name: Configure Build Matrix
         id: configure
@@ -99,6 +100,7 @@ jobs:
           ref: ${{ inputs.ref }}
           submodules: recursive
           fetch-tags: true
+          persist-credentials: false
 
       - name: Install Linux deps
         if: runner.os == 'Linux'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,6 +33,7 @@ jobs:
           # We must use 'fetch-depth: 2', or else the linter won't have another
           # revision to compare to.
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Lint
         shell: bash

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -48,6 +48,7 @@ jobs:
           ref: ${{ inputs.tag }}
           submodules: recursive
           fetch-tags: true
+          persist-credentials: false
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -44,6 +44,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag }}
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -55,6 +55,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-tags: true
+          persist-credentials: false
 
       - name: Compute latest
         id: compute

--- a/.github/workflows/test-linux-distros.yaml
+++ b/.github/workflows/test-linux-distros.yaml
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
 
       - name: Configure Build Matrix
         id: configure
@@ -69,6 +70,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           submodules: recursive
+          persist-credentials: false
 
       - name: Build in Docker
         run: ./packager/testing/test_dockers.sh "${{ matrix.os_name }}"


### PR DESCRIPTION
See actions/checkout#485 and https://johnstawinski.com/2024/01/11/playing-with-fire-how-we-executed-a-critical-supply-chain-attack-on-pytorch/

In short, it is a terrible idea to persist even our default credentials after checkout. There's no call for that, so we will now set `persist-credentials: false` on all checkout actions.