### PR TITLE
ci: Update OpenSUSE dockerfile to 15.6

### DIFF
--- a/packager/testing/dockers/OpenSUSE_Dockerfile
+++ b/packager/testing/dockers/OpenSUSE_Dockerfile
@@ -1,17 +1,11 @@
-FROM opensuse/leap:15.5
-
-# OpenSUSE 15.5 doesn't have the required CMake 3.24+, but we can add it
-# through another repo:
-RUN zypper addrepo \
-    https://download.opensuse.org/repositories/devel:tools:building/15.5/devel:tools:building.repo
-RUN zypper --no-gpg-checks refresh
+FROM opensuse/leap:15.6
 
 # Install utilities, libraries, and dev tools.
 RUN zypper in -y \
         curl which \
         cmake gcc9-c++ git ninja python3
 
-# OpenSUSE 15.5 doesn't have the required gcc 9+ by default, but we can install
+# OpenSUSE 15.6 doesn't have the required gcc 9+ by default, but we can install
 # it as gcc9 and symlink it.
 RUN ln -s g++-9 /usr/bin/g++
 RUN ln -s gcc-9 /usr/bin/gcc


### PR DESCRIPTION
We no longer need a separate repo for CMake.

This fixes build failures on OpenSUSE 15.5.  The extra repo for CMake is no longer available.  So it's lucky we no longer need it with the latest OS.