### PR TITLE
feat(ci): Official multiarch docker images for x64 + arm64

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -7,11 +7,19 @@
 # A workflow to build the official docker image.
 name: Official Docker image
 
-# Runs when called from another workflow.
 on:
+  # Runs when called from another workflow.
   workflow_call:
     inputs:
       ref:
+        required: true
+        type: string
+
+  # Runs when triggered manually by a maintainer.
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: The ref to build from.
         required: true
         type: string
 
@@ -23,8 +31,19 @@ defaults:
 
 jobs:
   official_docker_image:
-    name: Build
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - docker_platform: linux/amd64
+            runs_on: ubuntu-latest
+
+          - docker_platform: linux/arm64
+            runs_on: ubuntu-24.04-arm
+
+    name: Build ${{ matrix.docker_platform }}
+    runs-on: ${{ matrix.runs_on }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -35,4 +54,4 @@ jobs:
 
       - name: Build
         shell: bash
-        run: docker buildx build .
+        run: docker buildx build --platform ${{ matrix.docker_platform }} .

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -7,9 +7,8 @@
 # A workflow to publish the official docker image.
 name: Publish to Docker Hub
 
-# Runs when called from another workflow.
-# Can also be run manually for debugging purposes.
 on:
+  # Runs when called from another workflow.
   workflow_call:
     inputs:
       tag:
@@ -25,7 +24,8 @@ on:
         required: true
       DOCKERHUB_PACKAGE_NAME:
         required: true
-  # For manual debugging:
+
+  # Runs when triggered manually by a maintainer.
   workflow_dispatch:
     inputs:
       tag:
@@ -38,9 +38,21 @@ on:
         type: boolean
 
 jobs:
+  # Following multiarch GitHub Actions guide from
+  # https://docs.docker.com/build/ci/github-actions/multi-platform/
   publish_docker_hub:
-    name: Publish to Docker Hub
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - docker_arch: amd64
+            runs_on: ubuntu-latest
+
+          - docker_arch: arm64
+            runs_on: ubuntu-24.04-arm
+
+    name: Build image for ${{ matrix.docker_arch }}
+    runs-on: ${{ matrix.runs_on }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -56,25 +68,80 @@ jobs:
           username: ${{ secrets.DOCKERHUB_CI_USERNAME }}
           password: ${{ secrets.DOCKERHUB_CI_TOKEN }}
 
-      - name: Push to Docker Hub
-        uses: docker/build-push-action@v5
-        with:
-          # Important: use actions/checkout source, which has the right tags!
-          # Without context: ., this action will try to fetch git source
-          # itself, and it will be unable to determine the correct version
-          # number.
-          context: .
-          push: true
-          tags: ${{ secrets.DOCKERHUB_PACKAGE_NAME }}:${{ inputs.tag }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Push to Docker Hub as "latest"
-        if: ${{ inputs.latest }}
-        uses: docker/build-push-action@v5
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
         with:
           # Important: use actions/checkout source, which has the right tags!
           # Without context: ., this action will try to fetch git source
           # itself, and it will be unable to determine the correct version
           # number.
           context: .
-          push: true
-          tags: ${{ secrets.DOCKERHUB_PACKAGE_NAME }}:latest
+          platforms: linux/${{ matrix.docker_arch }}
+          #FIXME: labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ secrets.DOCKERHUB_PACKAGE_NAME }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.docker_arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # We do this as separate build and merge steps, rather than the one-step
+  # docker/build-push-action with multiple platforms, because that one-step
+  # method uses emulation that is _painfully_ slow.  We can build for arm64
+  # natively in parallel with x64 in about 1/6 the time of using emulation to
+  # do it on a single runner.  The cost is just this longer workflow.
+  publish_docker_hub_multiarch:
+    name: Publish to Docker Hub (multiarch)
+    needs: publish_docker_hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_CI_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_CI_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Merge multiarch and push to tag
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          # Get digests from file names in this folder
+          formatted_digests=$(printf '${{ secrets.DOCKERHUB_PACKAGE_NAME }}@sha256:%s ' *)
+          docker buildx imagetools create \
+              --tag ${{ secrets.DOCKERHUB_PACKAGE_NAME }}:${{ inputs.tag }} \
+              $formatted_digests
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ secrets.DOCKERHUB_PACKAGE_NAME }}:${{ inputs.tag }}
+
+      - name: Tag multiarch as "latest"
+        if: ${{ inputs.latest }}
+        run: |
+          # Push out an alias to the tagged multiarch version we already pushed.
+          docker buildx imagetools create \
+              --tag ${{ secrets.DOCKERHUB_PACKAGE_NAME }}:latest \
+              ${{ secrets.DOCKERHUB_PACKAGE_NAME }}:${{ inputs.tag }}

--- a/.github/workflows/test-linux-distros.yaml
+++ b/.github/workflows/test-linux-distros.yaml
@@ -7,13 +7,22 @@
 # A workflow to test building in various Linux distros.
 name: Test Linux Distros
 
-# Runs when called from another workflow.
 on:
+  # Runs when called from another workflow.
   workflow_call:
     inputs:
       ref:
         required: true
         type: string
+
+  # Runs when triggered manually by a maintainer.
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: The ref to build from.
+        required: true
+        type: string
+
 
 # By default, run all commands in a bash shell.  On Windows, the default would
 # otherwise be powershell.
@@ -39,10 +48,28 @@ jobs:
         shell: node {0}
         run: |
           const fs = require('fs');
-          const files = fs.readdirSync('packager/testing/dockers/');
-          const matrix = files.map((file) => {
-            return { os_name: file.replace('_Dockerfile', '') };
-          });
+
+          const folder = 'packager/testing/dockers/';
+          const files = fs.readdirSync(folder);
+
+          const matrix = [];
+          for (const file of files) {
+            const os_name = file.replace('_Dockerfile', '');
+            matrix.push({
+              os_name,
+              docker_platform: 'linux/amd64',
+              runs_on: 'ubuntu-latest',
+            });
+
+            const contents = fs.readFileSync(folder + file);
+            if (/\bNOARM\b/.exec(contents) == null) {
+              matrix.push({
+                os_name,
+                docker_platform: 'linux/arm64',
+                runs_on: 'ubuntu-24.04-arm',
+              });
+            }
+          }
 
           // Output a JSON object consumed by the build matrix below.
           fs.writeFileSync(process.env.GITHUB_OUTPUT,
@@ -62,8 +89,8 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.docker_matrix_config.outputs.MATRIX) }}
 
-    name: ${{ matrix.os_name }}
-    runs-on: ubuntu-latest
+    name: ${{ matrix.os_name }} on ${{ matrix.docker_platform }}
+    runs-on: ${{ matrix.runs_on }}
 
     steps:
       - uses: actions/checkout@v4

--- a/packager/testing/dockers/ArchLinux_Dockerfile
+++ b/packager/testing/dockers/ArchLinux_Dockerfile
@@ -1,4 +1,5 @@
 FROM archlinux:latest
+# NOARM - tells workflow to skip arm for this, because there is no arm image
 
 # Install utilities, libraries, and dev tools.
 RUN pacman -Suy --needed --noconfirm \

--- a/packager/testing/dockers/CentOS_Dockerfile
+++ b/packager/testing/dockers/CentOS_Dockerfile
@@ -1,4 +1,5 @@
 FROM tgagor/centos:stream9
+# NOARM - tells workflow to skip arm for this, because there is no arm image
 
 # For CentOS, Ninja is only available from the "CRB" ("Code Ready Builder")
 # repo.  Enable that first.


### PR DESCRIPTION
This adds support for Docker-based testing on arm64 images and runners.

This also adds a multiarch build process so that future releases cover both x64 and arm64.

This is tagged as "feat" so that this gets called out in the changelog for the next release.