### PR TITLE
ci: Use a mirror of musl.cc

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -190,7 +190,7 @@ jobs:
             else
               MUSL_ARCH="x86_64"
             fi
-            curl -LO https://musl.cc/"$MUSL_ARCH"-linux-musl-native.tgz
+            curl -LO https://joeyparrish.github.io/musl-cc-mirror/"$MUSL_ARCH"-linux-musl-native.tgz
             tar xf "$MUSL_ARCH"-linux-musl-native.tgz
             export CC=`pwd`/"$MUSL_ARCH"-linux-musl-native/bin/"$MUSL_ARCH"-linux-musl-gcc
             export CXX=`pwd`/"$MUSL_ARCH"-linux-musl-native/bin/"$MUSL_ARCH"-linux-musl-g++


### PR DESCRIPTION
musl.cc is overwhelmed by GitHub traffic, and therefore has blocked all of Microsoft.  This switches to a mirror run on GitHub so that we can continue to access the toolchains.