### PR TITLE
chore: Fix build in Arch and other dockers

### DIFF
--- a/packager/app/manifest_flags.h
+++ b/packager/app/manifest_flags.h
@@ -9,6 +9,8 @@
 #ifndef PACKAGER_APP_MANIFEST_FLAGS_H_
 #define PACKAGER_APP_MANIFEST_FLAGS_H_
 
+#include <cstdint>
+
 #include <absl/flags/declare.h>
 #include <absl/flags/flag.h>
 

--- a/packager/file/callback_file.h
+++ b/packager/file/callback_file.h
@@ -4,6 +4,8 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+#include <cstdint>
+
 #include <packager/file.h>
 
 namespace shaka {

--- a/packager/file/http_file.h
+++ b/packager/file/http_file.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_FILE_HTTP_H_
 #define PACKAGER_FILE_HTTP_H_
 
+#include <cstdint>
 #include <memory>
 #include <string>
 

--- a/packager/file/threaded_io_file.h
+++ b/packager/file/threaded_io_file.h
@@ -8,6 +8,7 @@
 #define PACKAGER_FILE_THREADED_IO_FILE_H_
 
 #include <atomic>
+#include <cstdint>
 #include <memory>
 
 #include <absl/synchronization/mutex.h>

--- a/packager/file/udp_options.h
+++ b/packager/file/udp_options.h
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+#include <cstdint>
 #include <memory>
 #include <string>
 

--- a/packager/hls/base/hls_notifier.h
+++ b/packager/hls/base/hls_notifier.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_HLS_BASE_HLS_NOTIFIER_H_
 #define PACKAGER_HLS_BASE_HLS_NOTIFIER_H_
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/packager/hls/base/media_playlist.h
+++ b/packager/hls/base/media_playlist.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_HLS_BASE_MEDIA_PLAYLIST_H_
 #define PACKAGER_HLS_BASE_MEDIA_PLAYLIST_H_
 
+#include <cstdint>
 #include <filesystem>
 #include <list>
 #include <memory>

--- a/packager/hls/base/mock_media_playlist.h
+++ b/packager/hls/base/mock_media_playlist.h
@@ -7,6 +7,8 @@
 #ifndef PACKAGER_HLS_BASE_MOCK_MEDIA_PLAYLIST_H_
 #define PACKAGER_HLS_BASE_MOCK_MEDIA_PLAYLIST_H_
 
+#include <cstdint>
+
 #include <gmock/gmock.h>
 
 #include <packager/hls/base/media_playlist.h>

--- a/packager/hls/base/simple_hls_notifier.h
+++ b/packager/hls/base/simple_hls_notifier.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_HLS_BASE_SIMPLE_HLS_NOTIFIER_H_
 #define PACKAGER_HLS_BASE_SIMPLE_HLS_NOTIFIER_H_
 
+#include <cstdint>
 #include <list>
 #include <map>
 #include <memory>

--- a/packager/media/base/aes_cryptor.h
+++ b/packager/media/base/aes_cryptor.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_BASE_AES_CRYPTOR_H_
 #define PACKAGER_MEDIA_BASE_AES_CRYPTOR_H_
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>

--- a/packager/media/base/aes_decryptor.h
+++ b/packager/media/base/aes_decryptor.h
@@ -9,6 +9,7 @@
 #ifndef PACKAGER_MEDIA_BASE_AES_DECRYPTOR_H_
 #define PACKAGER_MEDIA_BASE_AES_DECRYPTOR_H_
 
+#include <cstdint>
 #include <vector>
 
 #include <packager/macros/classes.h>

--- a/packager/media/base/aes_encryptor.h
+++ b/packager/media/base/aes_encryptor.h
@@ -9,6 +9,7 @@
 #ifndef PACKAGER_MEDIA_BASE_AES_ENCRYPTOR_H_
 #define PACKAGER_MEDIA_BASE_AES_ENCRYPTOR_H_
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/packager/media/base/aes_pattern_cryptor.h
+++ b/packager/media/base/aes_pattern_cryptor.h
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+#include <cstdint>
 #include <memory>
 
 #include <packager/macros/classes.h>

--- a/packager/media/base/audio_stream_info.h
+++ b/packager/media/base/audio_stream_info.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_BASE_AUDIO_STREAM_INFO_H_
 #define PACKAGER_MEDIA_BASE_AUDIO_STREAM_INFO_H_
 
+#include <cstdint>
 #include <vector>
 
 #include <packager/media/base/stream_info.h>

--- a/packager/media/base/cc_stream_filter.h
+++ b/packager/media/base/cc_stream_filter.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_BASE_CC_STREAM_FILTER_H_
 #define PACKAGER_MEDIA_BASE_CC_STREAM_FILTER_H_
 
+#include <cstdint>
 #include <string>
 
 #include <packager/media/base/media_handler.h>

--- a/packager/media/base/common_pssh_generator.h
+++ b/packager/media/base/common_pssh_generator.h
@@ -7,6 +7,8 @@
 #ifndef PACKAGER_MEDIA_BASE_COMMON_PSSH_GENERATOR_H_
 #define PACKAGER_MEDIA_BASE_COMMON_PSSH_GENERATOR_H_
 
+#include <cstdint>
+
 #include <packager/media/base/pssh_generator.h>
 
 namespace shaka {

--- a/packager/media/base/decryptor_source.h
+++ b/packager/media/base/decryptor_source.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_BASE_DECRYPTOR_SOURCE_H_
 #define PACKAGER_MEDIA_BASE_DECRYPTOR_SOURCE_H_
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <vector>

--- a/packager/media/base/encryption_config.h
+++ b/packager/media/base/encryption_config.h
@@ -7,6 +7,8 @@
 #ifndef PACKAGER_MEDIA_BASE_ENCRYPTION_CONFIG_H_
 #define PACKAGER_MEDIA_BASE_ENCRYPTION_CONFIG_H_
 
+#include <cstdint>
+
 #include <packager/media/base/fourccs.h>
 #include <packager/media/base/protection_system_specific_info.h>
 

--- a/packager/media/base/key_source.h
+++ b/packager/media/base/key_source.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_BASE_KEY_SOURCE_H_
 #define PACKAGER_MEDIA_BASE_KEY_SOURCE_H_
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <string>

--- a/packager/media/base/media_handler_test_base.h
+++ b/packager/media/base/media_handler_test_base.h
@@ -7,6 +7,8 @@
 #ifndef PACKAGER_MEDIA_BASE_MEDIA_HANDLER_TEST_BASE_H_
 #define PACKAGER_MEDIA_BASE_MEDIA_HANDLER_TEST_BASE_H_
 
+#include <cstdint>
+
 #include <absl/strings/escaping.h>
 #include <absl/strings/numbers.h>
 #include <gmock/gmock.h>

--- a/packager/media/base/media_parser.h
+++ b/packager/media/base/media_parser.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_BASE_MEDIA_PARSER_H_
 #define PACKAGER_MEDIA_BASE_MEDIA_PARSER_H_
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>

--- a/packager/media/base/media_sample.h
+++ b/packager/media/base/media_sample.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_BASE_MEDIA_SAMPLE_H_
 #define PACKAGER_MEDIA_BASE_MEDIA_SAMPLE_H_
 
+#include <cstdint>
 #include <deque>
 #include <memory>
 #include <string>

--- a/packager/media/base/mock_aes_cryptor.h
+++ b/packager/media/base/mock_aes_cryptor.h
@@ -7,6 +7,8 @@
 #ifndef PACKAGER_MEDIA_BASE_MOCK_AES_CRYPTOR_H_
 #define PACKAGER_MEDIA_BASE_MOCK_AES_CRYPTOR_H_
 
+#include <cstdint>
+
 #include <packager/media/base/aes_cryptor.h>
 
 namespace shaka {

--- a/packager/media/base/muxer.h
+++ b/packager/media/base/muxer.h
@@ -9,6 +9,7 @@
 #ifndef PACKAGER_MEDIA_BASE_MUXER_H_
 #define PACKAGER_MEDIA_BASE_MUXER_H_
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 

--- a/packager/media/base/playready_key_source.h
+++ b/packager/media/base/playready_key_source.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_BASE_PLAYREADY_SOURCE_H_
 #define PACKAGER_MEDIA_BASE_PLAYREADY_SOURCE_H_
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>

--- a/packager/media/base/playready_pssh_generator.h
+++ b/packager/media/base/playready_pssh_generator.h
@@ -7,6 +7,7 @@
 #ifndef MEDIA_BASE_PLAYREADY_PSSH_GENERATOR_H_
 #define MEDIA_BASE_PLAYREADY_PSSH_GENERATOR_H_
 
+#include <cstdint>
 #include <string>
 
 #include <packager/media/base/fourccs.h>

--- a/packager/media/base/protection_system_ids.h
+++ b/packager/media/base/protection_system_ids.h
@@ -7,6 +7,8 @@
 #ifndef PACKAGER_MEDIA_BASE_PROTECTION_SYSTEM_IDS_H_
 #define PACKAGER_MEDIA_BASE_PROTECTION_SYSTEM_IDS_H_
 
+#include <cstdint>
+
 namespace shaka {
 namespace media {
 

--- a/packager/media/base/pssh_generator.h
+++ b/packager/media/base/pssh_generator.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_BASE_PSSH_GENERATOR_H_
 #define PACKAGER_MEDIA_BASE_PSSH_GENERATOR_H_
 
+#include <cstdint>
 #include <optional>
 #include <vector>
 

--- a/packager/media/base/pssh_generator_util.h
+++ b/packager/media/base/pssh_generator_util.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_BASE_PSSH_GENERATOR_UTIL_H_
 #define PACKAGER_MEDIA_BASE_PSSH_GENERATOR_UTIL_H_
 
+#include <cstdint>
 #include <iostream>
 #include <memory>
 #include <set>

--- a/packager/media/base/raw_key_source.h
+++ b/packager/media/base/raw_key_source.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_BASE_RAW_KEY_SOURCE_H_
 #define PACKAGER_MEDIA_BASE_RAW_KEY_SOURCE_H_
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>

--- a/packager/media/base/request_signer.h
+++ b/packager/media/base/request_signer.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_BASE_REQUEST_SIGNER_H_
 #define PACKAGER_MEDIA_BASE_REQUEST_SIGNER_H_
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>

--- a/packager/media/base/stream_info.h
+++ b/packager/media/base/stream_info.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_BASE_STREAM_INFO_H_
 #define PACKAGER_MEDIA_BASE_STREAM_INFO_H_
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>

--- a/packager/media/base/text_muxer.h
+++ b/packager/media/base/text_muxer.h
@@ -7,6 +7,8 @@
 #ifndef PACKAGER_MEDIA_BASE_TEXT_MUXER_H_
 #define PACKAGER_MEDIA_BASE_TEXT_MUXER_H_
 
+#include <cstdint>
+
 #include <packager/media/base/muxer.h>
 #include <packager/media/base/text_sample.h>
 #include <packager/media/base/text_stream_info.h>

--- a/packager/media/base/text_stream_info.h
+++ b/packager/media/base/text_stream_info.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_BASE_TEXT_STREAM_INFO_H_
 #define PACKAGER_MEDIA_BASE_TEXT_STREAM_INFO_H_
 
+#include <cstdint>
 #include <map>
 #include <string>
 

--- a/packager/media/base/video_stream_info.h
+++ b/packager/media/base/video_stream_info.h
@@ -7,6 +7,8 @@
 #ifndef PACKAGER_MEDIA_BASE_VIDEO_STREAM_INFO_H_
 #define PACKAGER_MEDIA_BASE_VIDEO_STREAM_INFO_H_
 
+#include <cstdint>
+
 #include <packager/media/base/stream_info.h>
 
 namespace shaka {

--- a/packager/media/base/widevine_key_source.h
+++ b/packager/media/base/widevine_key_source.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_BASE_WIDEVINE_KEY_SOURCE_H_
 #define PACKAGER_MEDIA_BASE_WIDEVINE_KEY_SOURCE_H_
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <thread>

--- a/packager/media/base/widevine_pssh_generator.h
+++ b/packager/media/base/widevine_pssh_generator.h
@@ -7,6 +7,8 @@
 #ifndef MEDIA_BASE_WIDEVINE_PSSH_GENERATOR_H_
 #define MEDIA_BASE_WIDEVINE_PSSH_GENERATOR_H_
 
+#include <cstdint>
+
 #include <packager/media/base/fourccs.h>
 #include <packager/media/base/pssh_generator.h>
 

--- a/packager/media/codecs/decoder_configuration_record.h
+++ b/packager/media/codecs/decoder_configuration_record.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_CODECS_DECODER_CONFIGURATION_RECORD_H_
 #define PACKAGER_MEDIA_CODECS_DECODER_CONFIGURATION_RECORD_H_
 
+#include <cstdint>
 #include <vector>
 
 #include <absl/log/check.h>

--- a/packager/media/codecs/dts_audio_specific_config.h
+++ b/packager/media/codecs/dts_audio_specific_config.h
@@ -6,10 +6,11 @@
 #ifndef PACKAGER_MEDIA_CODECS_DTS_AUDIO_SPECIFIC_CONFIG_H_
 #define PACKAGER_MEDIA_CODECS_DTS_AUDIO_SPECIFIC_CONFIG_H_
 
+#include <cstdint>
+#include <vector>
+
 #include <stddef.h>
 #include <stdint.h>
-
-#include <vector>
 
 namespace shaka {
 namespace media {

--- a/packager/media/codecs/h265_parser.h
+++ b/packager/media/codecs/h265_parser.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_CODECS_H265_PARSER_H_
 #define PACKAGER_MEDIA_CODECS_H265_PARSER_H_
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <vector>

--- a/packager/media/codecs/hls_audio_util.h
+++ b/packager/media/codecs/hls_audio_util.h
@@ -7,6 +7,8 @@
 #ifndef PACKAGER_MEDIA_CODECS_HLS_AUDIO_UTIL_H_
 #define PACKAGER_MEDIA_CODECS_HLS_AUDIO_UTIL_H_
 
+#include <cstdint>
+
 #include <packager/media/base/stream_info.h>
 
 namespace shaka {

--- a/packager/media/codecs/video_slice_header_parser.h
+++ b/packager/media/codecs/video_slice_header_parser.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_CODECS_VIDEO_SLICE_HEADER_PARSER_H_
 #define PACKAGER_MEDIA_CODECS_VIDEO_SLICE_HEADER_PARSER_H_
 
+#include <cstdint>
 #include <vector>
 
 #include <packager/macros/classes.h>

--- a/packager/media/codecs/webvtt_util.h
+++ b/packager/media/codecs/webvtt_util.h
@@ -5,6 +5,7 @@
 #ifndef PACKAGER_MEDIA_CODECS_WEBVTT_UTIL_H_
 #define PACKAGER_MEDIA_CODECS_WEBVTT_UTIL_H_
 
+#include <cstdint>
 #include <vector>
 
 namespace shaka {

--- a/packager/media/crypto/aes_encryptor_factory.h
+++ b/packager/media/crypto/aes_encryptor_factory.h
@@ -7,6 +7,8 @@
 #ifndef PACKAGER_MEDIA_CRYPTO_AES_ENCRYPTOR_FACTORY_H_
 #define PACKAGER_MEDIA_CRYPTO_AES_ENCRYPTOR_FACTORY_H_
 
+#include <cstdint>
+
 #include <packager/media/base/fourccs.h>
 #include <packager/media/base/stream_info.h>
 

--- a/packager/media/crypto/encryption_handler.h
+++ b/packager/media/crypto/encryption_handler.h
@@ -7,6 +7,8 @@
 #ifndef PACKAGER_MEDIA_CRYPTO_ENCRYPTION_HANDLER_H_
 #define PACKAGER_MEDIA_CRYPTO_ENCRYPTION_HANDLER_H_
 
+#include <cstdint>
+
 #include <packager/crypto_params.h>
 #include <packager/media/base/key_source.h>
 #include <packager/media/base/media_handler.h>

--- a/packager/media/crypto/sample_aes_ec3_cryptor.h
+++ b/packager/media/crypto/sample_aes_ec3_cryptor.h
@@ -7,6 +7,8 @@
 #ifndef PACKAGER_MEDIA_CRYPTO_SAMPLE_AES_EC3_CRYPTOR_H_
 #define PACKAGER_MEDIA_CRYPTO_SAMPLE_AES_EC3_CRYPTOR_H_
 
+#include <cstdint>
+
 #include <packager/media/base/aes_cryptor.h>
 
 namespace shaka {

--- a/packager/media/crypto/subsample_generator.h
+++ b/packager/media/crypto/subsample_generator.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_CRYPTO_SUBSAMPLE_GENERATOR_H_
 #define PACKAGER_MEDIA_CRYPTO_SUBSAMPLE_GENERATOR_H_
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 

--- a/packager/media/demuxer/demuxer.h
+++ b/packager/media/demuxer/demuxer.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_BASE_DEMUXER_H_
 #define PACKAGER_MEDIA_BASE_DEMUXER_H_
 
+#include <cstdint>
 #include <deque>
 #include <memory>
 #include <vector>

--- a/packager/media/event/combined_muxer_listener.h
+++ b/packager/media/event/combined_muxer_listener.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_EVENT_COMBINED_MUXER_LISTENER_H_
 #define PACKAGER_MEDIA_EVENT_COMBINED_MUXER_LISTENER_H_
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 

--- a/packager/media/event/hls_notify_muxer_listener.h
+++ b/packager/media/event/hls_notify_muxer_listener.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_EVENT_HLS_NOTIFY_MUXER_LISTENER_H_
 #define PACKAGER_MEDIA_EVENT_HLS_NOTIFY_MUXER_LISTENER_H_
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>

--- a/packager/media/event/mock_muxer_listener.h
+++ b/packager/media/event/mock_muxer_listener.h
@@ -7,6 +7,8 @@
 #ifndef PACKAGER_MEDIA_EVENT_MOCK_MUXER_LISTENER_H_
 #define PACKAGER_MEDIA_EVENT_MOCK_MUXER_LISTENER_H_
 
+#include <cstdint>
+
 #include <gmock/gmock.h>
 
 #include <packager/media/base/muxer_options.h>

--- a/packager/media/event/mpd_notify_muxer_listener.h
+++ b/packager/media/event/mpd_notify_muxer_listener.h
@@ -9,6 +9,7 @@
 #ifndef PACKAGER_MEDIA_EVENT_MPD_NOTIFY_MUXER_LISTENER_H_
 #define PACKAGER_MEDIA_EVENT_MPD_NOTIFY_MUXER_LISTENER_H_
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <vector>

--- a/packager/media/event/muxer_listener_factory.h
+++ b/packager/media/event/muxer_listener_factory.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_EVENT_MUXER_LISTENER_FACTORY_H_
 #define PACKAGER_MEDIA_EVENT_MUXER_LISTENER_FACTORY_H_
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>

--- a/packager/media/event/vod_media_info_dump_muxer_listener.h
+++ b/packager/media/event/vod_media_info_dump_muxer_listener.h
@@ -11,6 +11,7 @@
 #ifndef PACKAGER_MEDIA_EVENT_VOD_MEDIA_INFO_DUMP_MUXER_LISTENER_H_
 #define PACKAGER_MEDIA_EVENT_VOD_MEDIA_INFO_DUMP_MUXER_LISTENER_H_
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>

--- a/packager/media/formats/dvb/dvb_image.h
+++ b/packager/media/formats/dvb/dvb_image.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_DVB_DVB_IMAGE_H_
 #define PACKAGER_MEDIA_DVB_DVB_IMAGE_H_
 
+#include <cstdint>
 #include <memory>
 #include <type_traits>
 

--- a/packager/media/formats/dvb/dvb_sub_parser.h
+++ b/packager/media/formats/dvb/dvb_sub_parser.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_DVB_DVB_SUB_PARSER_H_
 #define PACKAGER_MEDIA_DVB_DVB_SUB_PARSER_H_
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 

--- a/packager/media/formats/dvb/subtitle_composer.h
+++ b/packager/media/formats/dvb/subtitle_composer.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_DVB_SUBTITLE_COMPOSER_H_
 #define PACKAGER_MEDIA_DVB_SUBTITLE_COMPOSER_H_
 
+#include <cstdint>
 #include <memory>
 #include <unordered_map>
 #include <vector>

--- a/packager/media/formats/mp2t/es_parser_audio.h
+++ b/packager/media/formats/mp2t/es_parser_audio.h
@@ -5,6 +5,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP2T_ES_PARSER_AUDIO_H_
 #define PACKAGER_MEDIA_FORMATS_MP2T_ES_PARSER_AUDIO_H_
 
+#include <cstdint>
 #include <functional>
 #include <list>
 #include <memory>

--- a/packager/media/formats/mp2t/es_parser_dvb.h
+++ b/packager/media/formats/mp2t/es_parser_dvb.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP2T_ES_PARSER_DVB_H_
 #define PACKAGER_MEDIA_FORMATS_MP2T_ES_PARSER_DVB_H_
 
+#include <cstdint>
 #include <functional>
 #include <unordered_map>
 

--- a/packager/media/formats/mp2t/mp2t_media_parser.h
+++ b/packager/media/formats/mp2t/mp2t_media_parser.h
@@ -6,6 +6,7 @@
 #define PACKAGER_MEDIA_FORMATS_MP2T_MP2T_MEDIA_PARSER_H_
 
 #include <bitset>
+#include <cstdint>
 #include <deque>
 #include <map>
 #include <memory>

--- a/packager/media/formats/mp2t/pes_packet_generator.h
+++ b/packager/media/formats/mp2t/pes_packet_generator.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP2T_PES_PACKET_GENERATOR_H_
 #define PACKAGER_MEDIA_FORMATS_MP2T_PES_PACKET_GENERATOR_H_
 
+#include <cstdint>
 #include <list>
 #include <memory>
 

--- a/packager/media/formats/mp2t/ts_audio_type.h
+++ b/packager/media/formats/mp2t/ts_audio_type.h
@@ -7,7 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP2T_TS_AUDIO_TYPE_H
 #define PACKAGER_MEDIA_FORMATS_MP2T_TS_AUDIO_TYPE_H
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace shaka {
 namespace media {

--- a/packager/media/formats/mp2t/ts_muxer.h
+++ b/packager/media/formats/mp2t/ts_muxer.h
@@ -7,6 +7,8 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP2T_TS_MUXER_H_
 #define PACKAGER_MEDIA_FORMATS_MP2T_TS_MUXER_H_
 
+#include <cstdint>
+
 #include <packager/macros/classes.h>
 #include <packager/media/base/muxer.h>
 #include <packager/media/formats/mp2t/ts_segmenter.h>

--- a/packager/media/formats/mp2t/ts_section.h
+++ b/packager/media/formats/mp2t/ts_section.h
@@ -5,6 +5,8 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP2T_TS_SECTION_H_
 #define PACKAGER_MEDIA_FORMATS_MP2T_TS_SECTION_H_
 
+#include <cstdint>
+
 namespace shaka {
 namespace media {
 namespace mp2t {

--- a/packager/media/formats/mp2t/ts_section_pmt.h
+++ b/packager/media/formats/mp2t/ts_section_pmt.h
@@ -5,6 +5,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP2T_TS_SECTION_PMT_H_
 #define PACKAGER_MEDIA_FORMATS_MP2T_TS_SECTION_PMT_H_
 
+#include <cstdint>
 #include <functional>
 #include <string>
 

--- a/packager/media/formats/mp2t/ts_section_psi.h
+++ b/packager/media/formats/mp2t/ts_section_psi.h
@@ -5,6 +5,8 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP2T_TS_SECTION_PSI_H_
 #define PACKAGER_MEDIA_FORMATS_MP2T_TS_SECTION_PSI_H_
 
+#include <cstdint>
+
 #include <packager/macros/classes.h>
 #include <packager/media/base/byte_queue.h>
 #include <packager/media/formats/mp2t/ts_section.h>

--- a/packager/media/formats/mp2t/ts_segmenter.h
+++ b/packager/media/formats/mp2t/ts_segmenter.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP2T_TS_SEGMENTER_H_
 #define PACKAGER_MEDIA_FORMATS_MP2T_TS_SEGMENTER_H_
 
+#include <cstdint>
 #include <memory>
 
 #include <packager/file.h>

--- a/packager/media/formats/mp4/box_buffer.h
+++ b/packager/media/formats/mp4/box_buffer.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP4_BOX_BUFFER_H_
 #define PACKAGER_MEDIA_FORMATS_MP4_BOX_BUFFER_H_
 
+#include <cstdint>
 #include <string>
 
 #include <absl/log/check.h>

--- a/packager/media/formats/mp4/box_definitions.h
+++ b/packager/media/formats/mp4/box_definitions.h
@@ -5,6 +5,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP4_BOX_DEFINITIONS_H_
 #define PACKAGER_MEDIA_FORMATS_MP4_BOX_DEFINITIONS_H_
 
+#include <cstdint>
 #include <vector>
 
 #include <packager/media/base/decrypt_config.h>

--- a/packager/media/formats/mp4/box_reader.h
+++ b/packager/media/formats/mp4/box_reader.h
@@ -5,6 +5,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP4_BOX_READER_H_
 #define PACKAGER_MEDIA_FORMATS_MP4_BOX_READER_H_
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <vector>

--- a/packager/media/formats/mp4/low_latency_segment_segmenter.h
+++ b/packager/media/formats/mp4/low_latency_segment_segmenter.h
@@ -7,6 +7,8 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP4_LOW_LATENCY_SEGMENT_SEGMENTER_H_
 #define PACKAGER_MEDIA_FORMATS_MP4_LOW_LATENCY_SEGMENT_SEGMENTER_H_
 
+#include <cstdint>
+
 #include <packager/file.h>
 #include <packager/file/file_closer.h>
 #include <packager/macros/classes.h>

--- a/packager/media/formats/mp4/mp4_muxer.h
+++ b/packager/media/formats/mp4/mp4_muxer.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP4_MP4_MUXER_H_
 #define PACKAGER_MEDIA_FORMATS_MP4_MP4_MUXER_H_
 
+#include <cstdint>
 #include <optional>
 #include <vector>
 

--- a/packager/media/formats/mp4/segmenter.h
+++ b/packager/media/formats/mp4/segmenter.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP4_SEGMENTER_H_
 #define PACKAGER_MEDIA_FORMATS_MP4_SEGMENTER_H_
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <optional>

--- a/packager/media/formats/mp4/track_run_iterator.h
+++ b/packager/media/formats/mp4/track_run_iterator.h
@@ -5,6 +5,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_MP4_TRACK_RUN_ITERATOR_H_
 #define PACKAGER_MEDIA_FORMATS_MP4_TRACK_RUN_ITERATOR_H_
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <vector>

--- a/packager/media/formats/packed_audio/packed_audio_segmenter.h
+++ b/packager/media/formats/packed_audio/packed_audio_segmenter.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_PACKED_AUDIO_PACKED_AUDIO_SEGMENTER_H_
 #define PACKAGER_MEDIA_FORMATS_PACKED_AUDIO_PACKED_AUDIO_SEGMENTER_H_
 
+#include <cstdint>
 #include <memory>
 
 #include <packager/media/base/buffer_writer.h>

--- a/packager/media/formats/packed_audio/packed_audio_writer.h
+++ b/packager/media/formats/packed_audio/packed_audio_writer.h
@@ -7,6 +7,8 @@
 #ifndef PACKAGER_MEDIA_FORMATS_PACKED_AUDIO_PACKED_AUDIO_WRITER_H_
 #define PACKAGER_MEDIA_FORMATS_PACKED_AUDIO_PACKED_AUDIO_WRITER_H_
 
+#include <cstdint>
+
 #include <packager/file/file_closer.h>
 #include <packager/media/base/muxer.h>
 

--- a/packager/media/formats/ttml/ttml_generator.h
+++ b/packager/media/formats/ttml/ttml_generator.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_TTML_TTML_GENERATOR_H_
 #define PACKAGER_MEDIA_FORMATS_TTML_TTML_GENERATOR_H_
 
+#include <cstdint>
 #include <list>
 #include <map>
 #include <string>

--- a/packager/media/formats/ttml/ttml_muxer.h
+++ b/packager/media/formats/ttml/ttml_muxer.h
@@ -7,6 +7,8 @@
 #ifndef PACKAGER_MEDIA_FORMATS_TTML_TTML_MUXER_H_
 #define PACKAGER_MEDIA_FORMATS_TTML_TTML_MUXER_H_
 
+#include <cstdint>
+
 #include <packager/media/base/text_muxer.h>
 #include <packager/media/formats/ttml/ttml_generator.h>
 

--- a/packager/media/formats/webm/encryptor.h
+++ b/packager/media/formats/webm/encryptor.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_WEBM_ENCRYPTOR_H_
 #define PACKAGER_MEDIA_FORMATS_WEBM_ENCRYPTOR_H_
 
+#include <cstdint>
 #include <vector>
 
 #include <mkvmuxer/mkvmuxer.h>

--- a/packager/media/formats/webm/multi_segment_segmenter.h
+++ b/packager/media/formats/webm/multi_segment_segmenter.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_WEBM_MULTI_SEGMENT_SEGMENTER_H_
 #define PACKAGER_MEDIA_FORMATS_WEBM_MULTI_SEGMENT_SEGMENTER_H_
 
+#include <cstdint>
 #include <memory>
 
 #include <packager/macros/classes.h>

--- a/packager/media/formats/webm/segmenter.h
+++ b/packager/media/formats/webm/segmenter.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_WEBM_SEGMENTER_H_
 #define PACKAGER_MEDIA_FORMATS_WEBM_SEGMENTER_H_
 
+#include <cstdint>
 #include <memory>
 
 #include <mkvmuxer/mkvmuxer.h>

--- a/packager/media/formats/webm/segmenter_test_base.h
+++ b/packager/media/formats/webm/segmenter_test_base.h
@@ -7,6 +7,8 @@
 #ifndef PACKAGER_MEDIA_FORMATS_WEBM_SEGMENTER_TEST_UTILS_H_
 #define PACKAGER_MEDIA_FORMATS_WEBM_SEGMENTER_TEST_UTILS_H_
 
+#include <cstdint>
+
 #include <gtest/gtest.h>
 
 #include <packager/file/file_closer.h>

--- a/packager/media/formats/webm/single_segment_segmenter.h
+++ b/packager/media/formats/webm/single_segment_segmenter.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_WEBM_SINGLE_SEGMENT_SEGMENTER_H_
 #define PACKAGER_MEDIA_FORMATS_WEBM_SINGLE_SEGMENT_SEGMENTER_H_
 
+#include <cstdint>
 #include <memory>
 
 #include <packager/macros/classes.h>

--- a/packager/media/formats/webm/two_pass_single_segment_segmenter.h
+++ b/packager/media/formats/webm/two_pass_single_segment_segmenter.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_WEBM_TWO_PASS_SINGLE_SEGMENT_SEGMENTER_H_
 #define PACKAGER_MEDIA_FORMATS_WEBM_TWO_PASS_SINGLE_SEGMENT_SEGMENTER_H_
 
+#include <cstdint>
 #include <memory>
 #include <string>
 

--- a/packager/media/formats/webm/webm_audio_client.h
+++ b/packager/media/formats/webm/webm_audio_client.h
@@ -5,6 +5,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_WEBM_WEBM_AUDIO_CLIENT_H_
 #define PACKAGER_MEDIA_FORMATS_WEBM_WEBM_AUDIO_CLIENT_H_
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>

--- a/packager/media/formats/webm/webm_cluster_parser.h
+++ b/packager/media/formats/webm/webm_cluster_parser.h
@@ -5,6 +5,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_WEBM_WEBM_CLUSTER_PARSER_H_
 #define PACKAGER_MEDIA_FORMATS_WEBM_WEBM_CLUSTER_PARSER_H_
 
+#include <cstdint>
 #include <deque>
 #include <map>
 #include <memory>

--- a/packager/media/formats/webm/webm_content_encodings_client.h
+++ b/packager/media/formats/webm/webm_content_encodings_client.h
@@ -5,6 +5,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_WEBM_WEBM_CONTENT_ENCODINGS_CLIENT_H_
 #define PACKAGER_MEDIA_FORMATS_WEBM_WEBM_CONTENT_ENCODINGS_CLIENT_H_
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 

--- a/packager/media/formats/webm/webm_info_parser.h
+++ b/packager/media/formats/webm/webm_info_parser.h
@@ -6,6 +6,7 @@
 #define PACKAGER_MEDIA_FORMATS_WEBM_WEBM_INFO_PARSER_H_
 
 #include <chrono>
+#include <cstdint>
 
 #include <packager/macros/classes.h>
 #include <packager/media/formats/webm/webm_parser.h>

--- a/packager/media/formats/webm/webm_media_parser.h
+++ b/packager/media/formats/webm/webm_media_parser.h
@@ -5,6 +5,8 @@
 #ifndef PACKAGER_MEDIA_FORMATS_WEBM_WEBM_MEDIA_PARSER_H_
 #define PACKAGER_MEDIA_FORMATS_WEBM_WEBM_MEDIA_PARSER_H_
 
+#include <cstdint>
+
 #include <packager/macros/classes.h>
 #include <packager/media/base/byte_queue.h>
 #include <packager/media/base/media_parser.h>

--- a/packager/media/formats/webm/webm_tracks_parser.h
+++ b/packager/media/formats/webm/webm_tracks_parser.h
@@ -5,6 +5,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_WEBM_WEBM_TRACKS_PARSER_H_
 #define PACKAGER_MEDIA_FORMATS_WEBM_WEBM_TRACKS_PARSER_H_
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <set>

--- a/packager/media/formats/webm/webm_video_client.h
+++ b/packager/media/formats/webm/webm_video_client.h
@@ -5,6 +5,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_WEBM_WEBM_VIDEO_CLIENT_H_
 #define PACKAGER_MEDIA_FORMATS_WEBM_WEBM_VIDEO_CLIENT_H_
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>

--- a/packager/media/formats/webvtt/text_readers.h
+++ b/packager/media/formats/webvtt/text_readers.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_WEBVTT_TEXT_READERS_H_
 #define PACKAGER_MEDIA_FORMATS_WEBVTT_TEXT_READERS_H_
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>

--- a/packager/media/formats/webvtt/webvtt_file_buffer.h
+++ b/packager/media/formats/webvtt/webvtt_file_buffer.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_WEBVTT_WEBVTT_FILE_BUFFER_H_
 #define PACKAGER_MEDIA_FORMATS_WEBVTT_WEBVTT_FILE_BUFFER_H_
 
+#include <cstdint>
 #include <string>
 
 #include <packager/file.h>

--- a/packager/media/formats/webvtt/webvtt_muxer.h
+++ b/packager/media/formats/webvtt/webvtt_muxer.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_WEBVTT_WEBVTT_MUXER_H_
 #define PACKAGER_MEDIA_FORMATS_WEBVTT_WEBVTT_MUXER_H_
 
+#include <cstdint>
 #include <memory>
 
 #include <packager/media/base/text_muxer.h>

--- a/packager/media/formats/webvtt/webvtt_parser.h
+++ b/packager/media/formats/webvtt/webvtt_parser.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_WEBVTT_WEBVTT_PARSER_H_
 #define PACKAGER_MEDIA_FORMATS_WEBVTT_WEBVTT_PARSER_H_
 
+#include <cstdint>
 #include <map>
 #include <string>
 #include <vector>

--- a/packager/media/formats/wvm/wvm_media_parser.h
+++ b/packager/media/formats/wvm/wvm_media_parser.h
@@ -6,6 +6,7 @@
 #ifndef PACKAGER_MEDIA_FORMATS_WVM_WVM_MEDIA_PARSER_H_
 #define PACKAGER_MEDIA_FORMATS_WVM_WVM_MEDIA_PARSER_H_
 
+#include <cstdint>
 #include <deque>
 #include <map>
 #include <memory>

--- a/packager/media/trick_play/trick_play_handler.h
+++ b/packager/media/trick_play/trick_play_handler.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_BASE_TRICK_PLAY_HANDLER_H_
 #define PACKAGER_MEDIA_BASE_TRICK_PLAY_HANDLER_H_
 
+#include <cstdint>
 #include <list>
 
 #include <packager/media/base/media_handler.h>

--- a/packager/mpd/base/mock_mpd_builder.h
+++ b/packager/mpd/base/mock_mpd_builder.h
@@ -7,6 +7,8 @@
 #ifndef MPD_BASE_MOCK_MPD_BUILDER_H_
 #define MPD_BASE_MOCK_MPD_BUILDER_H_
 
+#include <cstdint>
+
 #include <absl/synchronization/mutex.h>
 #include <gmock/gmock.h>
 

--- a/packager/mpd/base/mock_mpd_notifier.h
+++ b/packager/mpd/base/mock_mpd_notifier.h
@@ -7,6 +7,8 @@
 #ifndef MPD_BASE_MOCK_MPD_NOTIFIER_H_
 #define MPD_BASE_MOCK_MPD_NOTIFIER_H_
 
+#include <cstdint>
+
 #include <gmock/gmock.h>
 
 #include <packager/mpd/base/content_protection_element.h>

--- a/packager/mpd/base/mpd_builder.h
+++ b/packager/mpd/base/mpd_builder.h
@@ -12,6 +12,7 @@
 #define MPD_BASE_MPD_BUILDER_H_
 
 #include <chrono>
+#include <cstdint>
 #include <list>
 #include <memory>
 #include <optional>

--- a/packager/mpd/base/mpd_notifier_util.h
+++ b/packager/mpd/base/mpd_notifier_util.h
@@ -10,6 +10,7 @@
 #ifndef MPD_BASE_MPD_NOTIFIER_UTIL_H_
 #define MPD_BASE_MPD_NOTIFIER_UTIL_H_
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/packager/mpd/base/period.h
+++ b/packager/mpd/base/period.h
@@ -9,6 +9,7 @@
 #ifndef PACKAGER_MPD_BASE_PERIOD_H_
 #define PACKAGER_MPD_BASE_PERIOD_H_
 
+#include <cstdint>
 #include <list>
 #include <map>
 #include <optional>

--- a/packager/mpd/base/simple_mpd_notifier.h
+++ b/packager/mpd/base/simple_mpd_notifier.h
@@ -7,6 +7,7 @@
 #ifndef MPD_BASE_SIMPLE_MPD_NOTIFIER_H_
 #define MPD_BASE_SIMPLE_MPD_NOTIFIER_H_
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <string>

--- a/packager/testing/test_dockers.sh
+++ b/packager/testing/test_dockers.sh
@@ -85,7 +85,8 @@ for DOCKER_FILE in ${SCRIPT_DIR}/dockers/*; do
   RAN_SOMETHING=1
   docker buildx build --pull -t ${CONTAINER} -f ${DOCKER_FILE} ${SCRIPT_DIR}/dockers/
   mkdir -p "${TEMP_BUILD_DIR}"
-  docker_run cmake -S . -B build/ -DCMAKE_BUILD_TYPE=Debug -G Ninja
+  docker_run cmake -S . -B build/ -DCMAKE_BUILD_TYPE=Debug -G Ninja \
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5
   docker_run cmake --build build/ --config Debug --parallel
   docker_run bash -c "cd build && ctest -C Debug -V"
   rm -rf "${TEMP_BUILD_DIR}"

--- a/packager/utils/absl_flag_hexbytes.h
+++ b/packager/utils/absl_flag_hexbytes.h
@@ -7,6 +7,8 @@
 #ifndef SHAKA_PACKAGER_ABSL_FLAG_HEXBYTES_H
 #define SHAKA_PACKAGER_ABSL_FLAG_HEXBYTES_H
 
+#include <cstdint>
+
 #include <absl/flags/flag.h>
 #include <absl/strings/ascii.h>
 #include <absl/strings/escaping.h>

--- a/packager/utils/bytes_to_string_view.h
+++ b/packager/utils/bytes_to_string_view.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_UTILS_BYTES_TO_STRING_VIEW_H_
 #define PACKAGER_UTILS_BYTES_TO_STRING_VIEW_H_
 
+#include <cstdint>
 #include <string_view>
 #include <vector>
 


### PR DESCRIPTION
This adds missing cstdint headers in every header where we reference a uint*_t.  This also adds a cmake definition that works around a guard in newer cmakes that is meant to guard against libraries that only work in older ones.