### PR TITLE
fix: pssh-box tool missing python_edition_defaults

### DIFF
--- a/packager/third_party/protobuf/embed_python_edition_defaults.cmake
+++ b/packager/third_party/protobuf/embed_python_edition_defaults.cmake
@@ -1,0 +1,50 @@
+# Copyright 2026 Google LLC. All rights reserved.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file or at
+# https://developers.google.com/open-source/licenses/bsd
+#
+# Embed a compile_edition_defaults binpb into the python runtime template.
+# Mirrors source/editions/internal_defaults_escape.cc with encoding=octal,
+# producing a Python bytes literal compatible with descriptor_pool.py.
+#
+# Required cache variables (pass via cmake -D):
+#   DEFAULTS_PATH   - path to descriptor_defaults.binpb
+#   TEMPLATE_PATH   - path to python_edition_defaults.py.template
+#   OUTPUT_PATH     - path to write python_edition_defaults.py
+#   PLACEHOLDER     - placeholder string in the template (e.g. DEFAULTS_VALUE)
+
+foreach(var DEFAULTS_PATH TEMPLATE_PATH OUTPUT_PATH PLACEHOLDER)
+  if(NOT DEFINED ${var})
+    message(FATAL_ERROR "embed_python_edition_defaults.cmake: ${var} not set")
+  endif()
+endforeach()
+
+file(READ "${DEFAULTS_PATH}" defaults_hex HEX)
+string(LENGTH "${defaults_hex}" hex_len)
+
+# Build a Python-compatible C-escaped bytes literal body. Printable ASCII
+# (except backslash and the surrounding double-quote) passes through verbatim;
+# everything else is emitted as \xNN. This matches what Python expects inside
+# b"..." and is equivalent to absl::CEscape for ASCII-only output.
+set(escaped "")
+set(i 0)
+while(i LESS hex_len)
+  string(SUBSTRING "${defaults_hex}" ${i} 2 byte_hex)
+  math(EXPR byte_val "0x${byte_hex}")
+  if(byte_val EQUAL 92)            # backslash
+    string(APPEND escaped "\\\\")
+  elseif(byte_val EQUAL 34)        # double quote
+    string(APPEND escaped "\\\"")
+  elseif(byte_val GREATER_EQUAL 32 AND byte_val LESS_EQUAL 126)
+    string(ASCII ${byte_val} ch)
+    string(APPEND escaped "${ch}")
+  else()
+    string(APPEND escaped "\\x${byte_hex}")
+  endif()
+  math(EXPR i "${i} + 2")
+endwhile()
+
+file(READ "${TEMPLATE_PATH}" template_contents)
+string(REPLACE "${PLACEHOLDER}" "${escaped}" rendered "${template_contents}")
+file(WRITE "${OUTPUT_PATH}" "${rendered}")

--- a/packager/third_party/protobuf/protobuf_py.cmake
+++ b/packager/third_party/protobuf/protobuf_py.cmake
@@ -58,6 +58,53 @@ foreach (filename ${protobuf_py_filenames})
             ${proto_path})
 endforeach ()
 
+# Generate google/protobuf/internal/python_edition_defaults.py. Upstream
+# protobuf only ships the .py.template; the real .py is produced by Bazel
+# rules (compile_edition_defaults + embed_edition_defaults). We replicate that
+# here so descriptor_pool.py can import python_edition_defaults at runtime.
+# Without this, `import google.protobuf.descriptor_pool` fails with
+# ImportError once the runtime is embedded into pssh-box-protos/ (see
+# https://github.com/shaka-project/shaka-packager/issues/1571).
+set(protobuf_py_edition_defaults_binpb
+    ${protobuf_py_output_path}/google/protobuf/internal/descriptor_defaults.binpb)
+set(protobuf_py_edition_defaults_py
+    ${protobuf_py_output_path}/google/protobuf/internal/python_edition_defaults.py)
+set(protobuf_py_edition_defaults_template
+    ${protobuf_py_library_path}/google/protobuf/internal/python_edition_defaults.py.template)
+
+add_custom_command(
+    DEPENDS
+        protoc
+        ${protobuf_py_proto_path}/google/protobuf/descriptor.proto
+        ${protobuf_py_output_path}/google
+    OUTPUT
+        ${protobuf_py_edition_defaults_binpb}
+    COMMAND
+        protoc
+    ARGS
+        -I${protobuf_py_proto_path}
+        --edition_defaults_out=${protobuf_py_edition_defaults_binpb}
+        --edition_defaults_minimum=PROTO2
+        --edition_defaults_maximum=2024
+        ${protobuf_py_proto_path}/google/protobuf/descriptor.proto)
+
+add_custom_command(
+    DEPENDS
+        ${protobuf_py_edition_defaults_binpb}
+        ${protobuf_py_edition_defaults_template}
+        ${CMAKE_CURRENT_SOURCE_DIR}/embed_python_edition_defaults.cmake
+    OUTPUT
+        ${protobuf_py_edition_defaults_py}
+    COMMAND
+        ${CMAKE_COMMAND}
+        -DDEFAULTS_PATH=${protobuf_py_edition_defaults_binpb}
+        -DTEMPLATE_PATH=${protobuf_py_edition_defaults_template}
+        -DOUTPUT_PATH=${protobuf_py_edition_defaults_py}
+        -DPLACEHOLDER=DEFAULTS_VALUE
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/embed_python_edition_defaults.cmake)
+
+list(APPEND protobuf_py_outputs ${protobuf_py_edition_defaults_py})
+
 # The entire python protobuf library (repo source and generated) to the output
 # folder.
 add_custom_target(protobuf_py ALL DEPENDS ${protobuf_py_outputs})

--- a/packager/tools/pssh/CMakeLists.txt
+++ b/packager/tools/pssh/CMakeLists.txt
@@ -42,6 +42,25 @@ add_custom_command(
 
 add_custom_target(pssh_box_py ALL DEPENDS ${PSSH_BOX_OUTPUTS})
 
+# Copy the test script next to the built pssh-box.py so it resolves
+# pssh-box-protos/ via its own directory.
+set(PSSH_BOX_TEST_PY ${CMAKE_BINARY_DIR}/packager/pssh_box_test.py)
+add_custom_command(
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/pssh_box_test.py
+    OUTPUT ${PSSH_BOX_TEST_PY}
+    COMMAND
+        ${CMAKE_COMMAND} -E copy
+        ${CMAKE_CURRENT_SOURCE_DIR}/pssh_box_test.py
+        ${PSSH_BOX_TEST_PY})
+add_custom_target(pssh_box_test_py_copy ALL
+    DEPENDS ${PSSH_BOX_TEST_PY} pssh_box_py)
+
+if(NOT SKIP_INTEGRATION_TESTS)
+  add_test(NAME pssh_box_py_test
+      COMMAND "${Python3_EXECUTABLE}" ${PSSH_BOX_TEST_PY}
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/packager)
+endif()
+
 # Always install the python tools.
 install(PROGRAMS ${CMAKE_BINARY_DIR}/packager/pssh-box.py
         DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/packager/tools/pssh/pssh-box.py
+++ b/packager/tools/pssh/pssh-box.py
@@ -95,7 +95,7 @@ class Pssh(object):
     self.version = version
     self.system_id = system_id
     self.key_ids = key_ids or []
-    self.pssh_data = pssh_data or ''
+    self.pssh_data = pssh_data or b''
 
   def binary_string(self):
     """Converts the PSSH box to a binary string."""

--- a/packager/tools/pssh/pssh_box_test.py
+++ b/packager/tools/pssh/pssh_box_test.py
@@ -31,10 +31,14 @@ PLAYREADY_SYSTEM_ID = '9A04F07998404286AB92E65BE0885F95'
 
 
 def run(*args):
-  result = subprocess.run([sys.executable, PSSH_BOX, *args],
+  # Use stdout/stderr=PIPE and universal_newlines instead of capture_output
+  # and text, which were only added in Python 3.7. Some supported distros
+  # (e.g. OpenSUSE Leap 15) still ship Python 3.6.
+  result = subprocess.run([sys.executable, PSSH_BOX] + list(args),
                           cwd=SCRIPT_DIR,
-                          capture_output=True,
-                          text=True,
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE,
+                          universal_newlines=True,
                           check=True)
   return result.stdout.strip()
 

--- a/packager/tools/pssh/pssh_box_test.py
+++ b/packager/tools/pssh/pssh_box_test.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC. All rights reserved.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file or at
+# https://developers.google.com/open-source/licenses/bsd
+
+"""End-to-end tests for pssh-box.py.
+
+Runs the installed script as a subprocess from its build directory so it
+picks up the bundled pssh-box-protos/ runtime. Regression coverage for:
+
+  * https://github.com/shaka-project/shaka-packager/issues/1571 -- import of
+    google.protobuf must succeed (python_edition_defaults.py present).
+  * https://github.com/shaka-project/shaka-packager/issues/1511 -- a Pssh
+    constructed without explicit pssh_data must not crash binary_string().
+"""
+
+import base64
+import os
+import subprocess
+import sys
+import unittest
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+PSSH_BOX = os.path.join(SCRIPT_DIR, 'pssh-box.py')
+
+WIDEVINE_KEY_ID = '11223344556677889900AABBCCDDEEFF'
+WIDEVINE_CONTENT_ID = '6361666562616265'  # b16 of "cafebabe"
+PLAYREADY_SYSTEM_ID = '9A04F07998404286AB92E65BE0885F95'
+
+
+def run(*args):
+  result = subprocess.run([sys.executable, PSSH_BOX, *args],
+                          cwd=SCRIPT_DIR,
+                          capture_output=True,
+                          text=True,
+                          check=True)
+  return result.stdout.strip()
+
+
+class PsshBoxTest(unittest.TestCase):
+
+  def test_widevine_human(self):
+    out = run('--human', '--widevine-system-id',
+              '--key-id', WIDEVINE_KEY_ID,
+              '--content-id', WIDEVINE_CONTENT_ID)
+    self.assertIn('Widevine edef8ba9-79d6-4ace-a3c8-27dcd51d21ed', out)
+    self.assertIn('11223344-5566-7788-9900-aabbccddeeff', out)
+    self.assertIn('Content ID: ' + WIDEVINE_CONTENT_ID, out)
+
+  def test_widevine_hex_and_base64_agree(self):
+    hex_out = run('--hex', '--widevine-system-id',
+                  '--key-id', WIDEVINE_KEY_ID,
+                  '--content-id', WIDEVINE_CONTENT_ID)
+    b64_out = run('--base64', '--widevine-system-id',
+                  '--key-id', WIDEVINE_KEY_ID,
+                  '--content-id', WIDEVINE_CONTENT_ID)
+    self.assertEqual(bytes.fromhex(hex_out), base64.b64decode(b64_out))
+
+  def test_round_trip_widevine(self):
+    """Encode -> decode -> re-encode must be byte-identical."""
+    hex_a = run('--hex', '--widevine-system-id',
+                '--key-id', WIDEVINE_KEY_ID,
+                '--content-id', WIDEVINE_CONTENT_ID)
+    b64 = base64.b64encode(bytes.fromhex(hex_a)).decode()
+    hex_b = run('--hex', '--from-base64', b64)
+    self.assertEqual(hex_a, hex_b)
+
+  def test_non_widevine_key_id_only_does_not_crash(self):
+    """Regression for #1511: a non-Widevine box with only --key-id used to
+    raise `TypeError: can't concat str to bytes` because the default
+    pssh_data was '' (str) instead of b''."""
+    hex_out = run('--hex',
+                  '--system-id', PLAYREADY_SYSTEM_ID,
+                  '--key-id', WIDEVINE_KEY_ID)
+    raw = bytes.fromhex(hex_out)
+    self.assertEqual(raw[4:8], b'pssh')
+    self.assertEqual(raw[8], 1)  # version 1, since --key-id was given
+
+  def test_two_box_mixed_systems(self):
+    """The original reporter command from #1511: Widevine box followed by a
+    PlayReady box with only a key-id. Must succeed and round-trip cleanly."""
+    hex_out = run('--hex', '--widevine-system-id',
+                  '--key-id', WIDEVINE_KEY_ID,
+                  '--content-id', WIDEVINE_CONTENT_ID,
+                  '--', '--system-id', PLAYREADY_SYSTEM_ID,
+                  '--key-id', WIDEVINE_KEY_ID)
+    b64 = base64.b64encode(bytes.fromhex(hex_out)).decode()
+    human = run('--human', '--from-base64', b64)
+    self.assertIn('PSSH Box v0', human)
+    self.assertIn('PSSH Box v1', human)
+    self.assertIn('Widevine', human)
+    self.assertIn('PlayReady', human)
+
+  def test_explicit_pssh_data_passthrough(self):
+    """--pssh-data takes a base64 string and goes through unchanged. This
+    exercises the path where pssh_data is already bytes on entry, ensuring
+    the b'' default change did not regress it."""
+    payload = b'hello world'
+    out = run('--human',
+              '--system-id', PLAYREADY_SYSTEM_ID,
+              '--pssh-data', base64.b64encode(payload).decode())
+    self.assertIn('PlayReady', out)
+    self.assertIn('PSSH Data (size: %d)' % len(payload), out)
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
- **#1571** — `python_edition_defaults.py` was missing from the embedded protobuf runtime after the #1553 protobuf 33.5 bump, breaking every `pssh-box.py` invocation in the Docker image with `ImportError`. CMake now generates it via `protoc --edition_defaults_out` + a small escape helper, mirroring Bazel's `embed_edition_defaults` rule.

Chose this over `pip install protobuf` to stay consistent with #1438, where the maintainer explicitly embedded the full Python runtime so `pssh-box.py` has no external Python deps; #1562 kept that as the default and added `USE_SYSTEM_DEPENDENCIES` only as an opt-in escape hatch.

- **#1511** — `Pssh.__init__` defaulted `pssh_data` to `''` (str) instead of `b''`, crashing `binary_string()` for any non-Widevine box created with just `--key-id`.

Also adds `pssh_box_test.py` (6 subtests, wired into CTest) — the tool previously had zero automated coverage, which is why both bugs lingered.

Closes shaka-project/shaka-packager#1571
Closes shaka-project/shaka-packager#1511