### PR TITLE
fix: normalize video_full_range_flag to 0 or 1 in av1 codec string

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -54,6 +54,7 @@ Prakash Duggaraju <duggaraju@gmail.com>
 Qingquan Wang <wangqq1103@gmail.com>
 Richard Eklycke <richard@eklycke.se>
 Rintaro Kuroiwa <rkuroiwa@google.com>
+Rizkie Pratama <itsme@rizkiepratama.net>
 Samidh Talsania <talsania@audible.com>
 Sanil Raut <sr1990003@gmail.com>
 Sergio Ammirata <sergio@ammirata.net>

--- a/packager/media/codecs/av1_codec_configuration_record.cc
+++ b/packager/media/codecs/av1_codec_configuration_record.cc
@@ -97,12 +97,12 @@ std::string AV1CodecConfigurationRecord::GetCodecString(
     uint16_t transfer_characteristics,
     uint16_t matrix_coefficients,
     uint8_t video_full_range_flag) const {
-  return absl::StrFormat(
-      "av01.%d.%02d%c.%02d.%d.%d%d%d.%02d.%02d.%02d.%d", profile_, level_,
-      tier_ ? 'H' : 'M', bit_depth_, mono_chrome_, chroma_subsampling_x_,
-      chroma_subsampling_y_, chroma_sample_position_, color_primaries,
-      transfer_characteristics, matrix_coefficients,
-      video_full_range_flag ? 1 : 0);
+  return absl::StrFormat("av01.%d.%02d%c.%02d.%d.%d%d%d.%02d.%02d.%02d.%d",
+                         profile_, level_, tier_ ? 'H' : 'M', bit_depth_,
+                         mono_chrome_, chroma_subsampling_x_,
+                         chroma_subsampling_y_, chroma_sample_position_,
+                         color_primaries, transfer_characteristics,
+                         matrix_coefficients, video_full_range_flag ? 1 : 0);
 }
 
 }  // namespace media

--- a/packager/media/codecs/av1_codec_configuration_record.cc
+++ b/packager/media/codecs/av1_codec_configuration_record.cc
@@ -101,7 +101,8 @@ std::string AV1CodecConfigurationRecord::GetCodecString(
       "av01.%d.%02d%c.%02d.%d.%d%d%d.%02d.%02d.%02d.%d", profile_, level_,
       tier_ ? 'H' : 'M', bit_depth_, mono_chrome_, chroma_subsampling_x_,
       chroma_subsampling_y_, chroma_sample_position_, color_primaries,
-      transfer_characteristics, matrix_coefficients, video_full_range_flag);
+      transfer_characteristics, matrix_coefficients,
+      video_full_range_flag ? 1 : 0);
 }
 
 }  // namespace media

--- a/packager/media/codecs/av1_codec_configuration_record_unittest.cc
+++ b/packager/media/codecs/av1_codec_configuration_record_unittest.cc
@@ -53,6 +53,19 @@ TEST(AV1CodecConfigurationRecordTest, Success2) {
             "av01.1.21H.12.1.010.01.01.01.0");
 }
 
+TEST(AV1CodecConfigurationRecordTest, FullRangeNormalization) {
+  AV1CodecConfigurationRecord av1_config;
+  const uint8_t kAV1CodecConfigurationData[] = {
+      0x81, 0x04, 0x4E, 0x00,
+  };
+  ASSERT_TRUE(av1_config.Parse(
+      std::vector<uint8_t>(std::begin(kAV1CodecConfigurationData),
+                           std::end(kAV1CodecConfigurationData))));
+
+  EXPECT_EQ(av1_config.GetCodecString(9, 18, 9, 128),
+            "av01.0.04M.10.0.112.09.18.09.1");
+}
+
 TEST(AV1CodecConfigurationRecordTest, InsufficientData) {
   const uint8_t kAV1CodecConfigurationData[] = {
       0x81,

--- a/packager/media/codecs/av1_codec_configuration_record_unittest.cc
+++ b/packager/media/codecs/av1_codec_configuration_record_unittest.cc
@@ -56,7 +56,10 @@ TEST(AV1CodecConfigurationRecordTest, Success2) {
 TEST(AV1CodecConfigurationRecordTest, FullRangeNormalization) {
   AV1CodecConfigurationRecord av1_config;
   const uint8_t kAV1CodecConfigurationData[] = {
-      0x81, 0x04, 0x4E, 0x00,
+      0x81,
+      0x04,
+      0x4E,
+      0x00,
   };
   ASSERT_TRUE(av1_config.Parse(
       std::vector<uint8_t>(std::begin(kAV1CodecConfigurationData),


### PR DESCRIPTION
This are PR for solving issue  https://github.com/shaka-project/shaka-packager/issues/1585
video_full_range_flag is passed as uint8_t and may hold the raw value
128 (0x80) when the full-range bit is set in the container — it is
never normalized to 0/1 before reaching GetCodecString(). When
formatted with %d this produces an invalid codec string such as:

  av01.0.04M.10.0.112.09.18.09.128

The AV1 codec string spec requires videoFullRangeFlag to be exactly
0 or 1, so players fail to parse or reject the string entirely.

Fix by explicitly normalizing with `video_full_range_flag ? 1 : 0`,
ensuring the output always matches the spec. Adds a regression test
with input data that triggers the 128 value.