### PR TITLE
fix(isobmff): validate stts entry count before allocation

### DIFF
--- a/packager/media/formats/mp4/box_definitions.cc
+++ b/packager/media/formats/mp4/box_definitions.cc
@@ -718,6 +718,9 @@ bool DecodingTimeToSample::ReadWriteInternal(BoxBuffer* buffer) {
   uint32_t count = static_cast<uint32_t>(decoding_time.size());
   RCHECK(ReadWriteHeaderInternal(buffer) && buffer->ReadWriteUInt32(&count));
 
+  if (buffer->Reading())
+    RCHECK(count <= buffer->BytesLeft() / sizeof(DecodingTime));
+
   decoding_time.resize(count);
   for (uint32_t i = 0; i < count; ++i) {
     RCHECK(buffer->ReadWriteUInt32(&decoding_time[i].sample_count) &&


### PR DESCRIPTION
This adds a bounds check for the `stts` box entry count before resizing the `decoding_time` vector while parsing MP4 data.

Without this check, a malformed file can declare an entry count larger than the remaining box payload, causing Shaka Packager to attempt an excessive allocation before parsing fails. The new validation ensures the declared count can fit in the remaining bytes before resizing.
