### PR TITLE
fix(mp4): size next_fragment_start_dts_ by max track_id to fix OOB crash

### DIFF
--- a/packager/media/formats/mp4/track_run_iterator.cc
+++ b/packager/media/formats/mp4/track_run_iterator.cc
@@ -297,8 +297,20 @@ bool TrackRunIterator::Init() {
 bool TrackRunIterator::Init(const MovieFragment& moof) {
   runs_.clear();
 
-  const auto track_count = std::max(moof.tracks.size(), moov_->tracks.size());
-  next_fragment_start_dts_.resize(track_count, 0);
+  // |next_fragment_start_dts_| is indexed by |track_id - 1| (see below), so it
+  // must be large enough to hold the largest track_id. track_ids are not
+  // required to be contiguous or to start at 1, so this is not necessarily the
+  // same as the number of tracks: sizing by the track count caused an
+  // out-of-bounds access for files whose track_id exceeds the track count.
+  // See https://github.com/shaka-project/shaka-packager/issues/1368.
+  uint32_t max_track_id = 0;
+  for (const auto& track : moov_->tracks)
+    max_track_id = std::max(max_track_id, track.header.track_id);
+  for (const auto& moof_track : moof.tracks)
+    max_track_id = std::max(max_track_id, moof_track.header.track_id);
+  // Only grow: values persist across fragments and must not be dropped.
+  if (next_fragment_start_dts_.size() < max_track_id)
+    next_fragment_start_dts_.resize(max_track_id, 0);
   for (size_t i = 0; i < moof.tracks.size(); i++) {
     const TrackFragment& traf = moof.tracks[i];
     const auto track_index = traf.header.track_id - 1;

--- a/packager/media/formats/mp4/track_run_iterator_unittest.cc
+++ b/packager/media/formats/mp4/track_run_iterator_unittest.cc
@@ -369,6 +369,30 @@ TEST_F(TrackRunIteratorTest, BasicOperationTest) {
   EXPECT_FALSE(iter_->IsRunValid());
 }
 
+TEST_F(TrackRunIteratorTest, HighTrackIdDoesNotOverflowNextFragmentDts) {
+  // Regression test for
+  // https://github.com/shaka-project/shaka-packager/issues/1368.
+  // track_ids are not required to be contiguous or bounded by the number of
+  // tracks. A file with a single track whose track_id is larger than the track
+  // count previously caused an out-of-bounds access on
+  // |next_fragment_start_dts_|, which is indexed by track_id - 1, resulting in
+  // a crash. Use track_id 101 to mirror the file from the issue.
+  const uint32_t kHighTrackId = 101;
+  moov_.tracks[0].header.track_id = kHighTrackId;
+  moov_.extends.tracks[0].track_id = kHighTrackId;
+
+  iter_.reset(new TrackRunIterator(&moov_));
+  MovieFragment moof = CreateFragment();
+  // Keep only the (audio) track and give it the high track_id.
+  moof.tracks.resize(1);
+  moof.tracks[0].header.track_id = kHighTrackId;
+
+  ASSERT_TRUE(iter_->Init(moof));
+  ASSERT_TRUE(iter_->IsRunValid());
+  EXPECT_TRUE(iter_->is_audio());
+  EXPECT_EQ(iter_->track_id(), kHighTrackId);
+}
+
 TEST_F(TrackRunIteratorTest, TrackExtendsDefaultsTest) {
   moov_.extends.tracks[0].default_sample_duration = 50;
   moov_.extends.tracks[0].default_sample_size = 3;


### PR DESCRIPTION
TrackRunIterator::Init(const MovieFragment&) sized next_fragment_start_dts_ to the number of tracks, but indexes it by track_id - 1. track_ids are not required to be contiguous or bounded by the track count, so a file whose track_id exceeds the number of tracks caused an out-of-bounds access.

For the file in the issue (a single-track fragmented MP4 whose track_id is 101), next_fragment_start_dts_ was sized to 1 while the code wrote to index 100, roughly 800 bytes past the allocation. Whether this faults depends on heap layout, which is why it crashed for reporters on some builds/platforms while appearing to work on others; the value written is only read back when tfdt is absent, so output was otherwise correct.

Size the vector by the maximum track_id seen in the movie and fragment instead, growing only so persisted cross-fragment values are retained.

Verified with a new unit test that reproduces the crash (deterministic under Guard Malloc / a sanitizer) and by packaging the reporter's file, which previously crashed and now succeeds.

Fixes #1368