### PR TITLE
fix: harden MP4/codec parsers against out-of-bounds boundary conditions

### DIFF
--- a/packager/media/codecs/h265_parser.cc
+++ b/packager/media/codecs/h265_parser.cc
@@ -1466,6 +1466,7 @@ H265Parser::Result H265Parser::ParseReferencePictureSet(
       for (int j = ref_num_positive_pics - 1; j >= 0; j--) {
         int d_poc = ref_pic_sets[ref_rps_idx].delta_poc_s1[j] + delta_rps;
         if (d_poc < 0 && use_delta[ref_num_negative_pics + j]) {
+          TRUE_OR_RETURN(i < kMaxRefPicSetCount);
           out_ref_pic_set->delta_poc_s0[i] = d_poc;
           out_ref_pic_set->used_by_curr_pic_s0[i] =
               used_by_curr_pic[ref_num_negative_pics + j];
@@ -1473,6 +1474,7 @@ H265Parser::Result H265Parser::ParseReferencePictureSet(
         }
       }
       if (delta_rps < 0 && use_delta[ref_num_delta_pocs]) {
+        TRUE_OR_RETURN(i < kMaxRefPicSetCount);
         out_ref_pic_set->delta_poc_s0[i] = delta_rps;
         out_ref_pic_set->used_by_curr_pic_s0[i] =
             used_by_curr_pic[ref_num_delta_pocs];
@@ -1481,6 +1483,7 @@ H265Parser::Result H265Parser::ParseReferencePictureSet(
       for (int j = 0; j < ref_num_negative_pics; j++) {
         int d_poc = ref_pic_sets[ref_rps_idx].delta_poc_s0[j] + delta_rps;
         if (d_poc < 0 && use_delta[j]) {
+          TRUE_OR_RETURN(i < kMaxRefPicSetCount);
           out_ref_pic_set->delta_poc_s0[i] = d_poc;
           out_ref_pic_set->used_by_curr_pic_s0[i] = used_by_curr_pic[j];
           i++;
@@ -1495,12 +1498,14 @@ H265Parser::Result H265Parser::ParseReferencePictureSet(
       for (int j = ref_num_negative_pics - 1; j >= 0; j--) {
         int d_poc = ref_pic_sets[ref_rps_idx].delta_poc_s0[j] + delta_rps;
         if (d_poc > 0 && use_delta[j]) {
+          TRUE_OR_RETURN(i < kMaxRefPicSetCount);
           out_ref_pic_set->delta_poc_s1[i] = d_poc;
           out_ref_pic_set->used_by_curr_pic_s1[i] = used_by_curr_pic[j];
           i++;
         }
       }
       if (delta_rps > 0 && use_delta[ref_num_delta_pocs]) {
+        TRUE_OR_RETURN(i < kMaxRefPicSetCount);
         out_ref_pic_set->delta_poc_s1[i] = delta_rps;
         out_ref_pic_set->used_by_curr_pic_s1[i] =
             used_by_curr_pic[ref_num_delta_pocs];
@@ -1509,6 +1514,7 @@ H265Parser::Result H265Parser::ParseReferencePictureSet(
       for (int j = 0; j < ref_num_positive_pics; j++) {
         int d_poc = ref_pic_sets[ref_rps_idx].delta_poc_s1[j] + delta_rps;
         if (d_poc > 0 && use_delta[ref_num_negative_pics + j]) {
+          TRUE_OR_RETURN(i < kMaxRefPicSetCount);
           out_ref_pic_set->delta_poc_s1[i] = d_poc;
           out_ref_pic_set->used_by_curr_pic_s1[i] =
               used_by_curr_pic[ref_num_negative_pics + j];

--- a/packager/media/codecs/vp9_parser.cc
+++ b/packager/media/codecs/vp9_parser.cc
@@ -99,6 +99,9 @@ bool ParseIfSuperframeIndex(const uint8_t* data,
                             size_t data_size,
                             std::vector<VPxFrameInfo>* vpx_frames) {
   vpx_frames->clear();
+  // An empty buffer has no superframe index byte to read; guard against the
+  // out-of-bounds read of data[data_size - 1] when data_size == 0.
+  RCHECK(data_size > 0);
   uint8_t superframe_marker = data[data_size - 1];
   VPxFrameInfo vpx_frame;
   if ((superframe_marker & 0xe0) != 0xc0) {

--- a/packager/media/codecs/vp9_parser_unittest.cc
+++ b/packager/media/codecs/vp9_parser_unittest.cc
@@ -67,6 +67,15 @@ TEST(VP9ParserTest, Superframe) {
   ASSERT_FALSE(parser.Parse(data, std::size(data), &frames));
 }
 
+TEST(VP9ParserTest, EmptyBuffer) {
+  // An empty buffer must not read past the front of the buffer when looking for
+  // the superframe marker at data[data_size - 1].
+  VP9Parser parser;
+  std::vector<VPxFrameInfo> frames;
+  const uint8_t data[] = {0x00};
+  ASSERT_FALSE(parser.Parse(data, 0, &frames));
+}
+
 TEST(VP9ParserTest, KeyframeChroma420) {
   const uint8_t kData[] = {
       0x82, 0x49, 0x83, 0x42, 0x00, 0x01, 0xf0, 0x00, 0x74, 0x04, 0x38, 0x24,

--- a/packager/media/formats/mp2t/ac3_header.cc
+++ b/packager/media/formats/mp2t/ac3_header.cc
@@ -52,8 +52,11 @@ const size_t kFrameSizeCodeTable[][3] = {
 // @return the size of the frame (header + payload).
 size_t CalcFrameSize(uint8_t fscod, uint8_t frmsizecod) {
   const size_t kNumFscode = std::size(kAc3SampleRateTable);
-  DCHECK_LT(fscod, kNumFscode);
-  DCHECK_LT(frmsizecod, std::size(kFrameSizeCodeTable));
+  // fscod == 3 (reserved) and out-of-range frmsizecod are not indices into the
+  // tables. GetFrameSizeWithoutParsing() feeds unvalidated values here, so
+  // check at runtime rather than relying on DCHECK (compiled out in release).
+  if (fscod >= kNumFscode || frmsizecod >= std::size(kFrameSizeCodeTable))
+    return 0;
   // The order of frequencies are reversed in |kFrameSizeCodeTable| compared to
   // |kAc3SampleRateTable|.
   const int index = kNumFscode - 1 - fscod;

--- a/packager/media/formats/mp2t/ac3_header_unittest.cc
+++ b/packager/media/formats/mp2t/ac3_header_unittest.cc
@@ -162,6 +162,19 @@ TEST_F(Ac3HeaderTest, ParseVariousDataSize) {
   EXPECT_FALSE(ac3_header.Parse(ac3_frame_44100_hz_.data(), 5));
 }
 
+TEST_F(Ac3HeaderTest, GetFrameSizeWithoutParsingRejectsReservedFscod) {
+  // fscod == 3 is reserved. GetFrameSizeWithoutParsing() does not validate it
+  // before indexing the frame-size table, where it produced a negative
+  // (out-of-bounds) column index. It must return 0 instead. In the byte after
+  // the 16-bit CRC (data[4] = 0xC0): fscod = 0b11 = 3, frmsizecod = 0.
+  const uint8_t kFrame[] = {0x0B, 0x77, 0x00, 0x00, 0xC0,
+                            0x00, 0x00, 0x00, 0x00, 0x00};
+  Ac3Header ac3_header;
+  ASSERT_TRUE(ac3_header.IsSyncWord(kFrame));
+  EXPECT_EQ(static_cast<size_t>(0),
+            ac3_header.GetFrameSizeWithoutParsing(kFrame, sizeof(kFrame)));
+}
+
 }  // Namespace mp2t
 }  // namespace media
 }  // namespace shaka

--- a/packager/media/formats/mp2t/mpeg1_header.cc
+++ b/packager/media/formats/mp2t/mpeg1_header.cc
@@ -143,7 +143,9 @@ bool Mpeg1Header::Parse(const uint8_t* mpeg1_frame, size_t mpeg1_frame_size) {
 
   uint8_t btr_idx;
   RCHECK(frame.ReadBits(4, &btr_idx));
-  RCHECK(btr_idx > 0);
+  // btr_idx == 0 is "free format" and btr_idx == 0b1111 is the reserved "bad"
+  // value; both are out of range for kMpeg1BitrateTable (indices 0..14).
+  RCHECK(btr_idx > 0 && btr_idx < kMpeg1BitrateTableSize);
   bitrate_ = Mpeg1BitRate(btr_idx, version_, layer_);
 
   uint8_t sr_idx;
@@ -184,7 +186,7 @@ size_t Mpeg1Header::GetFrameSizeWithoutParsing(const uint8_t* data,
   uint8_t padded = (data[2] & 0b00000010) >> 1;
 
   if ((version == kMpeg1V_INV) || (layer == kMpeg1L_INV) || (btr_idx == 0) ||
-      (sr_idx == 0b11))
+      (btr_idx >= kMpeg1BitrateTableSize) || (sr_idx == 0b11))
     return 0;
 
   uint32_t bitrate = Mpeg1BitRate(btr_idx, version, layer);

--- a/packager/media/formats/mp2t/mpeg1_header_unittest.cc
+++ b/packager/media/formats/mp2t/mpeg1_header_unittest.cc
@@ -108,6 +108,21 @@ TEST_F(Mpeg1HeaderTest, Parsing) {
   EXPECT_FALSE(mpeg1_header.Parse(frame_inv_4_.data(), frame_inv_4_.size()));
 }
 
+TEST_F(Mpeg1HeaderTest, RejectsReservedBitrateIndex) {
+  // btr_idx == 0b1111 is the reserved "bad" bitrate value. It is out of range
+  // for kMpeg1BitrateTable (valid indices 0..14) and must be rejected rather
+  // than used as an out-of-bounds table index. Byte 2 is 0xF0: btr_idx=0b1111,
+  // sr_idx=0. Boundary-condition audit.
+  std::vector<uint8_t> frame;
+  ASSERT_TRUE(shaka::ValidHexStringToBytes("FFFDF00444333332114322", &frame));
+
+  Mpeg1Header mpeg1_header;
+  ASSERT_TRUE(mpeg1_header.IsSyncWord(frame.data()));
+  EXPECT_EQ(static_cast<size_t>(0), mpeg1_header.GetFrameSizeWithoutParsing(
+                                        frame.data(), frame.size()));
+  EXPECT_FALSE(mpeg1_header.Parse(frame.data(), frame.size()));
+}
+
 }  // Namespace mp2t
 }  // namespace media
 }  // namespace shaka

--- a/packager/media/formats/mp4/track_run_iterator.cc
+++ b/packager/media/formats/mp4/track_run_iterator.cc
@@ -238,7 +238,7 @@ bool TrackRunIterator::Init() {
       tri.track_type = stsd.type;
       if (tri.track_type == kAudio) {
         RCHECK(!stsd.audio_entries.empty());
-        if (desc_idx > stsd.audio_entries.size())
+        if (desc_idx >= stsd.audio_entries.size())
           desc_idx = 0;
         tri.audio_description = &stsd.audio_entries[desc_idx];
         // We don't support encrypted non-fragmented mp4 for now.
@@ -246,7 +246,7 @@ bool TrackRunIterator::Init() {
                    .default_is_protected == 0);
       } else if (tri.track_type == kVideo) {
         RCHECK(!stsd.video_entries.empty());
-        if (desc_idx > stsd.video_entries.size())
+        if (desc_idx >= stsd.video_entries.size())
           desc_idx = 0;
         tri.video_description = &stsd.video_entries[desc_idx];
         // We don't support encrypted non-fragmented mp4 for now.
@@ -333,13 +333,13 @@ bool TrackRunIterator::Init(const MovieFragment& moof) {
     switch (stsd.type) {
       case kAudio:
         RCHECK(!stsd.audio_entries.empty());
-        if (desc_idx > stsd.audio_entries.size())
+        if (desc_idx >= stsd.audio_entries.size())
           desc_idx = 0;
         audio_sample_entry = &stsd.audio_entries[desc_idx];
         break;
       case kVideo:
         RCHECK(!stsd.video_entries.empty());
-        if (desc_idx > stsd.video_entries.size())
+        if (desc_idx >= stsd.video_entries.size())
           desc_idx = 0;
         video_sample_entry = &stsd.video_entries[desc_idx];
         break;

--- a/packager/media/formats/mp4/track_run_iterator.cc
+++ b/packager/media/formats/mp4/track_run_iterator.cc
@@ -238,7 +238,7 @@ bool TrackRunIterator::Init() {
       tri.track_type = stsd.type;
       if (tri.track_type == kAudio) {
         RCHECK(!stsd.audio_entries.empty());
-        if (desc_idx > stsd.audio_entries.size())
+        if (desc_idx >= stsd.audio_entries.size())
           desc_idx = 0;
         tri.audio_description = &stsd.audio_entries[desc_idx];
         // We don't support encrypted non-fragmented mp4 for now.
@@ -246,7 +246,7 @@ bool TrackRunIterator::Init() {
                    .default_is_protected == 0);
       } else if (tri.track_type == kVideo) {
         RCHECK(!stsd.video_entries.empty());
-        if (desc_idx > stsd.video_entries.size())
+        if (desc_idx >= stsd.video_entries.size())
           desc_idx = 0;
         tri.video_description = &stsd.video_entries[desc_idx];
         // We don't support encrypted non-fragmented mp4 for now.
@@ -345,13 +345,13 @@ bool TrackRunIterator::Init(const MovieFragment& moof) {
     switch (stsd.type) {
       case kAudio:
         RCHECK(!stsd.audio_entries.empty());
-        if (desc_idx > stsd.audio_entries.size())
+        if (desc_idx >= stsd.audio_entries.size())
           desc_idx = 0;
         audio_sample_entry = &stsd.audio_entries[desc_idx];
         break;
       case kVideo:
         RCHECK(!stsd.video_entries.empty());
-        if (desc_idx > stsd.video_entries.size())
+        if (desc_idx >= stsd.video_entries.size())
           desc_idx = 0;
         video_sample_entry = &stsd.video_entries[desc_idx];
         break;

--- a/packager/media/formats/mp4/track_run_iterator_unittest.cc
+++ b/packager/media/formats/mp4/track_run_iterator_unittest.cc
@@ -369,6 +369,31 @@ TEST_F(TrackRunIteratorTest, BasicOperationTest) {
   EXPECT_FALSE(iter_->IsRunValid());
 }
 
+TEST_F(TrackRunIteratorTest, OutOfRangeSampleDescriptionIndexUsesFirstEntry) {
+  // Regression test: sample_description_index is one-indexed, and the code
+  // converts it to a zero-based desc_idx. A value pointing exactly one past the
+  // last entry (desc_idx == entries.size()) previously slipped through the
+  // range check (which used '>' instead of '>=') and read one element past the
+  // audio_entries vector. It must instead fall back to the first entry.
+  SampleDescription& audio_stsd =
+      moov_.tracks[0].media.information.sample_table.description;
+  ASSERT_EQ(audio_stsd.audio_entries.size(), 1u);
+  const uint32_t kMarkerSampleRate = 44100;
+  audio_stsd.audio_entries[0].samplerate = kMarkerSampleRate;
+
+  iter_.reset(new TrackRunIterator(&moov_));
+  MovieFragment moof = CreateFragment();
+  // One past the last valid one-based index (size 1 -> index 2 is out of
+  // range).
+  moof.tracks[0].header.sample_description_index =
+      static_cast<uint32_t>(audio_stsd.audio_entries.size()) + 1;
+
+  ASSERT_TRUE(iter_->Init(moof));
+  ASSERT_TRUE(iter_->IsRunValid());
+  ASSERT_TRUE(iter_->is_audio());
+  EXPECT_EQ(iter_->audio_description().samplerate, kMarkerSampleRate);
+}
+
 TEST_F(TrackRunIteratorTest, TrackExtendsDefaultsTest) {
   moov_.extends.tracks[0].default_sample_duration = 50;
   moov_.extends.tracks[0].default_sample_size = 3;

--- a/packager/media/formats/mp4/track_run_iterator_unittest.cc
+++ b/packager/media/formats/mp4/track_run_iterator_unittest.cc
@@ -393,6 +393,31 @@ TEST_F(TrackRunIteratorTest, HighTrackIdDoesNotOverflowNextFragmentDts) {
   EXPECT_EQ(iter_->track_id(), kHighTrackId);
 }
 
+TEST_F(TrackRunIteratorTest, OutOfRangeSampleDescriptionIndexUsesFirstEntry) {
+  // Regression test: sample_description_index is one-indexed, and the code
+  // converts it to a zero-based desc_idx. A value pointing exactly one past the
+  // last entry (desc_idx == entries.size()) previously slipped through the
+  // range check (which used '>' instead of '>=') and read one element past the
+  // audio_entries vector. It must instead fall back to the first entry.
+  SampleDescription& audio_stsd =
+      moov_.tracks[0].media.information.sample_table.description;
+  ASSERT_EQ(audio_stsd.audio_entries.size(), 1u);
+  const uint32_t kMarkerSampleRate = 44100;
+  audio_stsd.audio_entries[0].samplerate = kMarkerSampleRate;
+
+  iter_.reset(new TrackRunIterator(&moov_));
+  MovieFragment moof = CreateFragment();
+  // One past the last valid one-based index (size 1 -> index 2 is out of
+  // range).
+  moof.tracks[0].header.sample_description_index =
+      static_cast<uint32_t>(audio_stsd.audio_entries.size()) + 1;
+
+  ASSERT_TRUE(iter_->Init(moof));
+  ASSERT_TRUE(iter_->IsRunValid());
+  ASSERT_TRUE(iter_->is_audio());
+  EXPECT_EQ(iter_->audio_description().samplerate, kMarkerSampleRate);
+}
+
 TEST_F(TrackRunIteratorTest, TrackExtendsDefaultsTest) {
   moov_.extends.tracks[0].default_sample_duration = 50;
   moov_.extends.tracks[0].default_sample_size = 3;


### PR DESCRIPTION
Audit and fix a class of boundary-condition bugs (off-by-one range checks and parsed values used as unchecked array/table indices) across the media parsers. Each is reachable from crafted input and manifests as an out-of-bounds read or write; several only fault depending on heap layout, so they are verified with a deterministic reproduction under Guard Malloc.

- mp4/track_run_iterator: sample_description_index range check used '>' instead of '>=', so an index exactly one past the last entry read one element past audio_entries/video_entries (four sites, audio and video in both the fragmented and non-fragmented Init paths).

- codecs/h265_parser: in the inter-predicted short-term reference picture set derivation, the running index into the fixed-size delta_poc_s0/s1 and used_by_curr_pic_s0/s1 arrays (kMaxRefPicSetCount) was never bounded, so a crafted SPS could drive it past the end (out-of-bounds write). Guard each write.

- codecs/vp9_parser: ParseIfSuperframeIndex read data[data_size - 1] without checking for an empty buffer, reading before the start of the buffer for a zero-length frame (reachable from a WebM block with empty payload).

- mp2t/mpeg1_header: the 4-bit bitrate index value 0b1111 (reserved 'bad') was not rejected and indexed one past kMpeg1BitrateTable.

- mp2t/ac3_header: GetFrameSizeWithoutParsing fed unvalidated fscod (reserved value 3 yields a negative table column index) and frmsizecod into the frame-size table before Parse validated them.

Adds unit-test coverage for the newly-guarded cases where a crafted input is tractable to construct.