### PR TITLE
fix(mp4): skip empty CodecConfiguration box instead of corrupting output

### DIFF
--- a/packager/media/formats/mp4/box_definitions.cc
+++ b/packager/media/formats/mp4/box_definitions.cc
@@ -1629,7 +1629,14 @@ bool VideoSampleEntry::ReadWriteInternal(BoxBuffer* buffer) {
   if (codec_configuration.box_type == FOURCC_NULL)
     return false;
 
-  RCHECK(buffer->ReadWriteChild(&codec_configuration));
+  // CodecConfiguration is an optional child (its ComputeSize() is 0 when the
+  // data is empty). If a higher layer leaves it empty, it must be skipped
+  // rather than written via ReadWriteChild, which does not skip zero-sized
+  // boxes and would emit a box whose declared size disagrees with the bytes
+  // actually written, corrupting the file. Reading uses the same optional path
+  // so that such output still round-trips. See
+  // https://github.com/shaka-project/shaka-packager/issues/1142.
+  RCHECK(buffer->TryReadWriteChild(&codec_configuration));
 
   if (buffer->Reading()) {
     extra_codec_configs.clear();

--- a/packager/media/formats/mp4/box_definitions_unittest.cc
+++ b/packager/media/formats/mp4/box_definitions_unittest.cc
@@ -1192,6 +1192,31 @@ TEST_F(BoxDefinitionsTest, VPCodecConfiguration) {
   EXPECT_EQ(codec_configuration, codec_configuration_readback);
 }
 
+TEST_F(BoxDefinitionsTest, VideoSampleEntryWithEmptyCodecConfiguration) {
+  // Regression test for
+  // https://github.com/shaka-project/shaka-packager/issues/1142.
+  // If a higher layer leaves the CodecConfiguration empty, the box must not be
+  // serialized with a declared size (0) that disagrees with the bytes written,
+  // which previously corrupted the whole file. The empty box is skipped, so the
+  // total bytes written match the computed size and the entry round-trips.
+  VideoSampleEntry entry;
+  entry.format = FOURCC_avc1;
+  entry.data_reference_index = 1;
+  entry.width = 800;
+  entry.height = 600;
+  entry.codec_configuration.box_type = FOURCC_avcC;
+  // codec_configuration.data intentionally left empty.
+
+  entry.Write(this->buffer_.get());
+  EXPECT_EQ(entry.ComputeSize(), this->buffer_->Size());
+
+  VideoSampleEntry entry_readback;
+  ASSERT_TRUE(ReadBack(&entry_readback));
+  EXPECT_EQ(entry.width, entry_readback.width);
+  EXPECT_EQ(entry.height, entry_readback.height);
+  EXPECT_TRUE(entry_readback.codec_configuration.data.empty());
+}
+
 TEST_F(BoxDefinitionsTest, DTSSampleEntry) {
   AudioSampleEntry entry;
   entry.format = FOURCC_dtse;


### PR DESCRIPTION
CodecConfiguration::ComputeSizeInternal() returns 0 when its data is empty, but VideoSampleEntry wrote the box via ReadWriteChild, which (unlike TryReadWriteChild) does not skip zero-sized boxes. So when a higher layer left the codec configuration empty, the box was serialized (e.g. 12 bytes for a vpcC FullBox header) while declaring size 0, and the parent VideoSampleEntry did not account for those bytes. The result was a structurally corrupt file with mismatched box sizes.

CodecConfiguration is already modeled as an optional box (ComputeSize()==0 when empty). Write it via TryReadWriteChild so an empty box is skipped, and read it via the same optional path so such output still round-trips.

Adds a unit test that writes a VideoSampleEntry with an empty codec configuration and verifies the bytes written match the computed size and that it round-trips.

Fixes #1142