### PR TITLE
feat: omit PSSH in MP4 for DASH-IF IOP compliant output

### DIFF
--- a/docs/source/options/mp4_output_options.rst
+++ b/docs/source/options/mp4_output_options.rst
@@ -3,7 +3,10 @@ MP4 output options
 
 --mp4_include_pssh_in_stream
 
-    MP4 only: include pssh in the encrypted stream. Default enabled.
+    MP4 only: include pssh in the encrypted stream. Defaults to enabled,
+    except that when ``--generate_dash_if_iop_compliant_mpd`` is enabled (the
+    default) it defaults to disabled, because the pssh is carried in the
+    manifest instead. An explicit value always wins.
 
 --mp4_use_decoding_timestamp_in_timeline
 

--- a/packager/app/muxer_flags.cc
+++ b/packager/app/muxer_flags.cc
@@ -9,6 +9,7 @@
 #include <packager/app/muxer_flags.h>
 
 #include <cstdint>
+#include <optional>
 #include <string>
 
 #include <absl/flags/flag.h>
@@ -57,10 +58,13 @@ ABSL_FLAG(std::string,
           "",
           "Specify a directory in which to store temporary (intermediate) "
           " files. Used only if single_segment=true.");
-ABSL_FLAG(bool,
+ABSL_FLAG(std::optional<bool>,
           mp4_include_pssh_in_stream,
-          true,
-          "MP4 only: include pssh in the encrypted stream.");
+          std::nullopt,
+          "MP4 only: include pssh in the encrypted stream. Defaults to true, "
+          "except that when --generate_dash_if_iop_compliant_mpd is enabled "
+          "(the default) it defaults to false, because the pssh is carried in "
+          "the manifest instead. An explicit value always wins.");
 ABSL_FLAG(int32_t,
           transport_stream_timestamp_offset_ms,
           100,

--- a/packager/app/muxer_flags.h
+++ b/packager/app/muxer_flags.h
@@ -10,6 +10,7 @@
 #define APP_MUXER_FLAGS_H_
 
 #include <cstdint>
+#include <optional>
 #include <string>
 
 #include <absl/flags/declare.h>
@@ -21,7 +22,7 @@ ABSL_DECLARE_FLAG(double, fragment_duration);
 ABSL_DECLARE_FLAG(bool, fragment_sap_aligned);
 ABSL_DECLARE_FLAG(bool, generate_sidx_in_media_segments);
 ABSL_DECLARE_FLAG(std::string, temp_dir);
-ABSL_DECLARE_FLAG(bool, mp4_include_pssh_in_stream);
+ABSL_DECLARE_FLAG(std::optional<bool>, mp4_include_pssh_in_stream);
 ABSL_DECLARE_FLAG(int32_t, transport_stream_timestamp_offset_ms);
 ABSL_DECLARE_FLAG(int32_t, default_text_zero_bias_ms);
 ABSL_DECLARE_FLAG(int64_t, ts_ttx_heartbeat_shift);

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -572,8 +572,29 @@ std::optional<PackagingParams> GetPackagingParams() {
   Mp4OutputParams& mp4_params = packaging_params.mp4_output_params;
   mp4_params.generate_sidx_in_media_segments =
       absl::GetFlag(FLAGS_generate_sidx_in_media_segments);
-  mp4_params.include_pssh_in_stream =
+  // DASH-IF IOP and CMAF recommend against duplicating 'pssh' boxes in the
+  // media files when the same information is carried in the manifest. So when
+  // --mp4_include_pssh_in_stream is left unset, let
+  // --generate_dash_if_iop_compliant_mpd choose the default: exclude 'pssh'
+  // from the stream when generating an IOP compliant MPD, otherwise include it.
+  // An explicit --mp4_include_pssh_in_stream always wins. See
+  // https://github.com/shaka-project/shaka-packager/issues/640.
+  const std::optional<bool> include_pssh_in_stream =
       absl::GetFlag(FLAGS_mp4_include_pssh_in_stream);
+  if (include_pssh_in_stream.has_value()) {
+    mp4_params.include_pssh_in_stream = include_pssh_in_stream.value();
+  } else {
+    const bool iop_compliant =
+        absl::GetFlag(FLAGS_generate_dash_if_iop_compliant_mpd);
+    mp4_params.include_pssh_in_stream = !iop_compliant;
+    if (iop_compliant) {
+      LOG(INFO)
+          << "Excluding 'pssh' boxes from MP4 media files because "
+             "--generate_dash_if_iop_compliant_mpd is enabled; the 'pssh' "
+             "is carried in the manifest instead. Set "
+             "--mp4_include_pssh_in_stream=true to override.";
+    }
+  }
   mp4_params.low_latency_dash_mode = absl::GetFlag(FLAGS_low_latency_dash_mode);
 
   packaging_params.transport_stream_timestamp_offset_ms =

--- a/packager/app/test/packager_test.py
+++ b/packager/app/test/packager_test.py
@@ -555,8 +555,11 @@ class PackagerAppTest(unittest.TestCase):
     if key_rotation:
       flags.append('--crypto_period_duration=1')
 
-    if not include_pssh_in_stream:
-      flags.append('--mp4_include_pssh_in_stream=false')
+    # Pass the flag explicitly (unless None) so tests are unaffected by the
+    # default, which depends on --generate_dash_if_iop_compliant_mpd (see #640).
+    if include_pssh_in_stream is not None:
+      flags.append('--mp4_include_pssh_in_stream=' +
+                   ('true' if include_pssh_in_stream else 'false'))
 
     if not dash_if_iop:
       flags.append('--generate_dash_if_iop_compliant_mpd=false')
@@ -1415,6 +1418,18 @@ class PackagerFunctionalTest(PackagerAppTest):
         self._GetStreams(['audio', 'video']),
         self._GetFlags(
             encryption=True, include_pssh_in_stream=False, output_dash=True))
+    self._CheckTestResults('encryption-and-no-pssh-in-stream')
+
+  def testEncryptionDashIfIopExcludesPsshFromStreamByDefault(self):
+    # With --generate_dash_if_iop_compliant_mpd enabled (the default) and no
+    # explicit --mp4_include_pssh_in_stream, pssh must be excluded from the
+    # media files (it is carried in the manifest instead). The output is
+    # therefore identical to the explicit include_pssh_in_stream=False case.
+    # https://github.com/shaka-project/shaka-packager/issues/640
+    self.assertPackageSuccess(
+        self._GetStreams(['audio', 'video']),
+        self._GetFlags(
+            encryption=True, include_pssh_in_stream=None, output_dash=True))
     self._CheckTestResults('encryption-and-no-pssh-in-stream')
 
   def testEncryptionCbc1(self):


### PR DESCRIPTION
DASH-IF IOP (7.7.1) and CMAF (7.4.3) recommend against duplicating 'pssh' boxes in media files when the same information is carried in the manifest. Previously --mp4_include_pssh_in_stream defaulted to true, so encrypted DASH output carried 'pssh' in both the init segments and the MPD.

Make --mp4_include_pssh_in_stream a tri-state (std::optional<bool>). When it is left unset, --generate_dash_if_iop_compliant_mpd chooses the default: 'pssh' is excluded from the stream when generating an IOP compliant MPD (the default), and included otherwise. An explicit --mp4_include_pssh_in_stream always wins. This lets one flag change the default of the other without silently overriding the user.

The e2e helper now passes --mp4_include_pssh_in_stream explicitly so existing tests are unaffected by the new default; a new test covers the default (IOP-compliant) behavior, whose output matches the explicit include_pssh_in_stream=false case.

Fixes #640