### PR TITLE
fix: limit Widevine key requests to track types used by drm_label

### DIFF
--- a/packager/app/packager_util.cc
+++ b/packager/app/packager_util.cc
@@ -47,7 +47,8 @@ std::unique_ptr<RequestSigner> CreateSigner(const WidevineSigner& signer) {
 
 std::unique_ptr<KeySource> CreateEncryptionKeySource(
     FourCC protection_scheme,
-    const EncryptionParams& encryption_params) {
+    const EncryptionParams& encryption_params,
+    const std::vector<std::string>& used_drm_labels) {
   std::unique_ptr<KeySource> encryption_key_source;
   switch (encryption_params.key_provider) {
     case KeyProvider::kWidevine: {
@@ -74,6 +75,7 @@ std::unique_ptr<KeySource> CreateEncryptionKeySource(
       widevine_key_source->set_group_id(widevine.group_id);
       widevine_key_source->set_enable_entitlement_license(
           widevine.enable_entitlement_license);
+      widevine_key_source->set_track_types(used_drm_labels);
 
       Status status =
           widevine_key_source->FetchKeys(widevine.content_id, widevine.policy);

--- a/packager/app/packager_util.h
+++ b/packager/app/packager_util.h
@@ -10,6 +10,8 @@
 #define PACKAGER_APP_PACKAGER_UTIL_H_
 
 #include <memory>
+#include <string>
+#include <vector>
 
 #include <packager/media/base/fourccs.h>
 
@@ -30,11 +32,16 @@ class KeySource;
 /// fetches keys.
 /// @param protection_scheme specifies the protection scheme to be used for
 ///        encryption.
+/// @param used_drm_labels specifies the drm labels explicitly referenced by
+///        the stream descriptors. If non-empty, Widevine key requests are
+///        limited to these track types; otherwise all track types are
+///        requested.
 /// @return A std::unique_ptr containing a new KeySource, or nullptr if
 ///         encryption is not required.
 std::unique_ptr<KeySource> CreateEncryptionKeySource(
     FourCC protection_scheme,
-    const EncryptionParams& encryption_params);
+    const EncryptionParams& encryption_params,
+    const std::vector<std::string>& used_drm_labels);
 
 /// Create KeySource based on provided params for content decryption. Does not
 /// fetch keys.

--- a/packager/media/base/widevine_key_source.cc
+++ b/packager/media/base/widevine_key_source.cc
@@ -358,11 +358,16 @@ void WidevineKeySource::FillRequest(bool enable_key_rotation,
   DCHECK(request);
   *request = *common_encryption_request_;
 
-  request->add_tracks()->set_type("SD");
-  request->add_tracks()->set_type("HD");
-  request->add_tracks()->set_type("UHD1");
-  request->add_tracks()->set_type("UHD2");
-  request->add_tracks()->set_type("AUDIO");
+  if (track_types_.empty()) {
+    request->add_tracks()->set_type("SD");
+    request->add_tracks()->set_type("HD");
+    request->add_tracks()->set_type("UHD1");
+    request->add_tracks()->set_type("UHD2");
+    request->add_tracks()->set_type("AUDIO");
+  } else {
+    for (const std::string& track_type : track_types_)
+      request->add_tracks()->set_type(track_type);
+  }
 
   request->add_drm_types(ModularDrmType::WIDEVINE);
 

--- a/packager/media/base/widevine_key_source.h
+++ b/packager/media/base/widevine_key_source.h
@@ -87,6 +87,13 @@ class WidevineKeySource : public KeySource {
     enable_entitlement_license_ = enable_entitlement_license;
   }
 
+  /// Set the track types to request keys for. If not set or empty, all
+  /// track types (SD, HD, UHD1, UHD2, AUDIO) are requested.
+  /// Not protected by Mutex.  Must be called before FetchKeys().
+  void set_track_types(const std::vector<std::string>& track_types) {
+    track_types_ = track_types;
+  }
+
  private:
   typedef ProducerConsumerQueue<std::shared_ptr<EncryptionKeyMap>>
       EncryptionKeyQueue;
@@ -145,6 +152,7 @@ class WidevineKeySource : public KeySource {
   int32_t crypto_period_duration_in_seconds_ = 0;
   std::vector<uint8_t> group_id_;
   bool enable_entitlement_license_ = false;
+  std::vector<std::string> track_types_;
   std::unique_ptr<EncryptionKeyQueue> key_pool_;
 
   EncryptionKeyMap encryption_key_map_;  // For non key rotation request.

--- a/packager/media/base/widevine_key_source_unittest.cc
+++ b/packager/media/base/widevine_key_source_unittest.cc
@@ -333,6 +333,29 @@ TEST_F(WidevineKeySourceTest, GenerateSignatureFailure) {
             widevine_key_source_->FetchKeys(content_id_, kPolicy));
 }
 
+TEST_F(WidevineKeySourceTest, RequestOnlyConfiguredTrackTypes) {
+  const char kExpectedRequestMessageWithTrackTypesFormat[] =
+      R"({"content_id":"%s","policy":"%s",)"
+      R"("tracks":[{"type":"SD"},{"type":"AUDIO"}],)"
+      R"("drm_types":["WIDEVINE"],"protection_scheme":"%s"})";
+  std::string expected_message =
+      absl::StrFormat(kExpectedRequestMessageWithTrackTypesFormat,
+                      Base64Encode(kContentId).c_str(), kPolicy,
+                      GetExpectedProtectionScheme().c_str());
+  EXPECT_CALL(*mock_request_signer_,
+              GenerateSignature(StrEq(expected_message), _))
+      .WillOnce(DoAll(SetArgPointee<1>(kMockSignature), Return(true)));
+
+  const Status kMockStatus = Status::UNKNOWN;
+  EXPECT_CALL(*mock_key_fetcher_, FetchKeys(_, _, _))
+      .WillOnce(Return(kMockStatus));
+
+  CreateWidevineKeySource();
+  widevine_key_source_->set_signer(std::move(mock_request_signer_));
+  widevine_key_source_->set_track_types({"SD", "AUDIO"});
+  ASSERT_EQ(kMockStatus, widevine_key_source_->FetchKeys(content_id_, kPolicy));
+}
+
 TEST_F(WidevineKeySourceTest, RetryOnHttpTimeout) {
   std::string mock_response = absl::StrFormat(
       kHttpResponseFormat, Base64Encode(GenerateMockLicenseResponse()).c_str());

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -877,6 +877,25 @@ Status CreateAllJobs(const std::vector<StreamDescriptor>& stream_descriptors,
   return job_manager->InitializeJobs();
 }
 
+// Returns the distinct drm labels explicitly referenced by the stream
+// descriptors, or an empty vector if any encryptable stream omits the
+// label (in which case the key source must request all track types).
+std::vector<std::string> GetUsedDrmLabels(
+    const std::vector<StreamDescriptor>& stream_descriptors) {
+  std::vector<std::string> labels;
+  for (const StreamDescriptor& descriptor : stream_descriptors) {
+    if (descriptor.skip_encryption || descriptor.stream_selector == "text")
+      continue;
+    if (descriptor.drm_label.empty())
+      return {};
+    if (std::find(labels.begin(), labels.end(), descriptor.drm_label) ==
+        labels.end()) {
+      labels.push_back(descriptor.drm_label);
+    }
+  }
+  return labels;
+}
+
 }  // namespace
 }  // namespace media
 
@@ -913,7 +932,8 @@ Status Packager::Initialize(
     internal->encryption_key_source = CreateEncryptionKeySource(
         static_cast<media::FourCC>(
             packaging_params.encryption_params.protection_scheme),
-        packaging_params.encryption_params);
+        packaging_params.encryption_params,
+        media::GetUsedDrmLabels(stream_descriptors));
     if (!internal->encryption_key_source)
       return Status(error::INVALID_ARGUMENT, "Failed to create key source.");
   }


### PR DESCRIPTION
## Problem
`WidevineKeySource` hardcoded all five track types (SD, HD, UHD1, UHD2, AUDIO) in every key request and key rotation, creating orphaned key entries on license servers that persist keys per track type (e.g. DRM Today).

## Fix
When every encryptable stream descriptor specifies an explicit `drm_label`, request only the distinct referenced labels. When labels are derived at runtime from resolution, the previous request-everything behavior is kept.

## Testing
New `widevine_key_source_unittest` cases for label-restricted requests; full `media_base_unittest` passes.

Fixes #1575