### PR TITLE
fix: consume same-type child boxes in stream order in BoxReader::ReadChild

### DIFF
--- a/packager/media/formats/mp4/box_reader.cc
+++ b/packager/media/formats/mp4/box_reader.cc
@@ -100,8 +100,15 @@ bool BoxReader::ReadChild(Box* child) {
   DCHECK(scanned_);
   FourCC child_type = child->BoxType();
 
-  ChildMap::iterator itr = children_.find(child_type);
-  RCHECK(itr != children_.end());
+  // Use lower_bound() rather than find(): with multiple children of the same
+  // type (e.g. the 'url ' entries of a 'dref'), multimap::find() may return
+  // ANY element with the key — commonly the tree root, not the first in the
+  // stream — so repeated ReadChild+erase calls would consume same-type
+  // children out of order and scramble their payloads. lower_bound() is
+  // guaranteed to return the first of the equal range, and multimap preserves
+  // insertion (stream) order for equivalent keys.
+  ChildMap::iterator itr = children_.lower_bound(child_type);
+  RCHECK(itr != children_.end() && itr->first == child_type);
   DVLOG(2) << "Found a " << FourCCToString(child_type) << " box.";
   RCHECK(child->Parse(itr->second.get()));
   children_.erase(itr);


### PR DESCRIPTION
## Problem
`BoxReader::ReadChild` used `multimap::find()`, which for multiple children of the same type (e.g. the `url ` entries of a `dref`) may return **any** element with the key — in practice the tree root, i.e. the second-inserted child — rather than the first in stream order. Repeated ReadChild+erase calls then consume same-type children out of order (observed order 2,3,1), scrambling their payloads across entries.

This is visible as binary-layout-sensitive failures in the `BoxDefinitionTypedTests2` WriteModifyWrite round-trip tests (DataReference → Track containment chain): filtered runs may pass while the full suite fails on some toolchains, and building with `-ftrivial-auto-var-init=pattern` makes the failure deterministic. It is also a real parsing bug for any MP4 input whose boxes carry repeated same-type children read via sequential `ReadChild` calls.

## Fix
Use `lower_bound()`, which is guaranteed to return the first element of the equal range; multimap preserves insertion (stream) order for equivalent keys.

## Testing
Full `mp4_unittest` (352 tests) passes in normal, ASan, and `-ftrivial-auto-var-init=pattern` builds (macOS arm64 / clang; previously the pattern build failed these 5 tests deterministically).