### PR TITLE
docs: Fix and expand DRM documentation

### DIFF
--- a/docs/source/options/dash_options.rst
+++ b/docs/source/options/dash_options.rst
@@ -86,6 +86,12 @@ DASH options
     Ignored if $Time$ is used in segment template, since $Time$ requires
     accurate Segment Timeline.
 
+--include_mspr_pro_for_playready, --noinclude_mspr_pro_for_playready
+
+    If enabled, PlayReady Object <mspr:pro> is inserted into the
+    <ContentProtection ...> element alongside <cenc:pssh> when using the
+    PlayReady protection system. Enabled by default.
+
 --dash_only=0|1
 
     Optional. Defaults to 0 if not specified. If it is set to 1, indicates the

--- a/docs/source/tutorials/drm.rst
+++ b/docs/source/tutorials/drm.rst
@@ -15,8 +15,10 @@ are provided to Shaka Packager directly.
     /tutorials/cpix.rst
 
 Regardless of which key server you are using, you can instruct Shaka Packager to
-generate other protection systems in additional to the native protection system
-from the key server. This allows generating multi-DRM contents easily.
+generate other protection systems in addition to the native protection system
+from the key server, using *--protection_systems*. The content keys from the key
+server are reused for the additional protection systems, so multi-DRM content
+can be generated without providing any extra keys.
 
 Configuration options
 ---------------------
@@ -24,5 +26,6 @@ Configuration options
 .. include:: /options/drm_stream_descriptors.rst
 .. include:: /options/general_encryption_options.rst
 .. include:: /options/widevine_encryption_options.rst
+.. include:: /options/playready_encryption_options.rst
 .. include:: /options/raw_key_encryption_options.rst
 .. include:: /options/cpix_encryption_options.rst

--- a/docs/source/tutorials/playready.rst
+++ b/docs/source/tutorials/playready.rst
@@ -26,6 +26,49 @@ Synopsis
 The --client_cert_xx and --ca_file parameters can be omitted if not required by
 the key server.
 
+Generating PlayReady with other key sources
+-------------------------------------------
+
+A PlayReady key server is not required to generate PlayReady content. Add
+*PlayReady* to *--protection_systems* with any key source, and Shaka Packager
+generates the PlayReady header and PSSH from the content key and key ID that
+key source provides. This works with :doc:`/tutorials/raw_key`,
+:doc:`/tutorials/widevine` and :doc:`/tutorials/cpix`, and is the usual way to
+produce multi-DRM content without having to provide a second set of keys.
+
+PlayReady header
+----------------
+
+When Shaka Packager generates the PlayReady header itself, the protection
+scheme selects the header version:
+
+* 'cenc' and 'cens' produce a version 4.0.0.0 header using AESCTR.
+* 'cbcs' and 'cbc1' produce a version 4.3.0.0 header using AESCBC, which
+  requires PlayReady 4.0 or later clients.
+
+Extra elements, such as a <LAURL> license acquisition URL, can be added to the
+header with *--playready_extra_header_data*. This is optional, and is only
+needed for clients that cannot be told the license server URL by the
+application.
+
+When keys are fetched from a PlayReady key server, the header comes from the
+key server response instead, and *--playready_extra_header_data* does not
+apply.
+
+In DASH, the PlayReady ContentProtection element carries the header both as a
+<cenc:pssh> and as an <mspr:pro> element. See
+*--include_mspr_pro_for_playready* in the :doc:`/tutorials/dash` options.
+
+Limitations
+-----------
+
+The PlayReady key server integration fetches a single content key and uses it
+for every stream, so *drm_label* in the stream descriptors has no effect.
+
+Key rotation (*--crypto_period_duration*) is not implemented for the PlayReady
+key server; the same key is returned for every crypto period. Use another key
+source if you need key rotation or different keys per stream.
+
 Configuration options
 ---------------------
 

--- a/docs/source/tutorials/raw_key.rst
+++ b/docs/source/tutorials/raw_key.rst
@@ -103,11 +103,11 @@ The examples below use the H264 streams created in :doc:`encoding`.
 
     Users are responsible for setting up the license servers and managing keys
     there unless they are using a cloud service provided by the DRM provider or
-    third_parties.
+    third parties.
 
 Refer to
 `player setup <https://shaka-player-demo.appspot.com/docs/api/tutorial-drm-config.html>`_
-on how to config the DRM in Shaka Player.
+on how to configure the DRM in Shaka Player.
 
 Test vectors used in this tutorial
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/tutorials/widevine.rst
+++ b/docs/source/tutorials/widevine.rst
@@ -74,7 +74,9 @@ The examples below use the H264 streams created in :doc:`encoding`.
       --hls_master_playlist_output h264_master.m3u8
 
 The examples above generate Widevine protection system by default. It can be
-extended to support multi-drm with --protection_systems flag.
+extended to support multi-drm with --protection_systems flag. The content keys
+fetched from the Widevine key server are also used to generate the signaling
+for the other protection systems, so no additional keys have to be provided.
 
 * Example with multi-drm (Widevine and PlayReady)::
 
@@ -90,23 +92,23 @@ extended to support multi-drm with --protection_systems flag.
       --signer widevine_test \
       --aes_signing_key 1ae8ccd0e7985cc0b6203a55855a1034afc252980e970ca90e5202689f947ab9 \
       --aes_signing_iv d58ce954203b7c9a9a9d467f59839249 \
-      --protection_systems Widevine,PlayReady
+      --protection_systems Widevine,PlayReady \
       --mpd_output h264.mpd
 
 .. note::
 
     Users are responsible for setting up the license servers and managing keys
     there unless they are using a cloud service provided by the DRM provider or
-    third_parties.
+    third parties.
 
 Refer to
 `player setup <https://shaka-player-demo.appspot.com/docs/api/tutorial-drm-config.html>`_
-on how to config the DRM in Shaka Player.
+on how to configure the DRM in Shaka Player.
 
 Widevine test credential
 ------------------------
 
-Here is the test crendential used in this tutorial.
+Here is the test credential used in this tutorial.
 
 :key_server_url:
 


### PR DESCRIPTION
Several DRM documentation fixes:

 - Fixes a missing line continuation in the multi-DRM example in the Widevine tutorial, which made the example fail to run as written.
 - `--include_mspr_pro_for_playready` was not documented at all.
 - The PlayReady options were not included in the DRM page, even though every other key source's options were.
 - The PlayReady tutorial did not mention that PlayReady can be generated from any key source with `--protection_systems`, that the protection scheme selects the WRMHEADER version (4.0 for cenc/cens, 4.3 for cbcs/cbc1), or that the key server integration uses a single key for all streams and does not implement key rotation.